### PR TITLE
test(docs-integrity): resolve CodeQL regex-anchor alert (code-scanning 24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic versioning.
 
+## [Unreleased]
+
+### Security
+
+- **Resolve a CodeQL `js/regex/missing-regexp-anchor` alert** in the
+  docs-integrity guard. The upstream-credit assertion matched its target link
+  with an unanchored regex; it now uses a literal, scheme-qualified substring
+  check instead — stricter (a bare host mention no longer satisfies it) and
+  regex-free. Test-only; no change to shipped behavior.
+
 ## [1.1.0] — 2026-07-08
 
 Dashboard release. The compression path and billing math are unchanged; this is

--- a/tests/docs-integrity.test.ts
+++ b/tests/docs-integrity.test.ts
@@ -166,7 +166,11 @@ describe('docs integrity', () => {
     const readme = fs.readFileSync(path.join(repoRoot, 'README.md'), 'utf8');
     const block = /<!--\s*omniglyph:upstream-credits:start\s*-->([\s\S]*?)<!--\s*omniglyph:upstream-credits:end\s*-->/.exec(readme);
     expect(block, 'README.md must contain the omniglyph:upstream-credits marker pair').not.toBeNull();
-    expect(block![1]).toMatch(/github\.com\/teamchong\/pxpipe/);
+    // Literal substring, not a regex: the credit must be the canonical upstream
+    // URL (scheme included). Using a plain `.toContain` keeps this an exact
+    // presence check and avoids an unanchored URL regex (CodeQL
+    // js/regex/missing-regexp-anchor), which a bare host pattern would trip.
+    expect(block![1]).toContain('https://github.com/teamchong/pxpipe');
     expect(block![1]).toMatch(/acknowledg/i);
   });
 


### PR DESCRIPTION
Resolves CodeQL code-scanning alert **24** (`js/regex/missing-regexp-anchor`,
high) in `tests/docs-integrity.test.ts`.

### The alert
The upstream-credit assertion matched its target link with an **unanchored
regex** (`/github\.com\/teamchong\/pxpipe/`). CodeQL flags this because a bare
host pattern can match a look-alike host embedded anywhere in the surrounding
text (arbitrary chars may precede/follow it).

### The fix
The pattern carried **no metacharacters** — it was a substring check written as
a regex. It is replaced with a literal, scheme-qualified presence check:

```diff
- expect(block![1]).toMatch(/github\.com\/teamchong\/pxpipe/);
+ expect(block![1]).toContain('https://github.com/teamchong/pxpipe');
```

- Removing the regex means the rule **cannot fire** on this line.
- The check is **strictly stricter**: it now requires the canonical `https://`
  URL, so a bare unscheme'd mention — which the old regex accepted — no longer
  satisfies the guard. Verified by mutation: the assertion passes on the real
  link, and fails both on a bare-host mention and on a removed link.

### Validation
- Full suite **921/921** · `lint` · `typecheck` · `build` — all clean
- `docs-integrity` isolated: 5/5 (rebrand guard + link-checker unaffected)

Test-only; **no change to shipped behavior**. CHANGELOG updated under
`[Unreleased] → Security`.

> Left open for review — do not merge on my behalf.
