### PR TITLE
fix(transform): stop counting the reflow ↵ sentinel as a visual row break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic ver
 
 ### Fixed
 
+- **fix(transform):** the profitability gate no longer counts the reflow ↵
+  sentinel as a visual row break. Reflow packs hard newlines into one
+  soft-wrapped stream (↵ is an inline glyph the renderer never breaks on), so
+  treating it as a break overstated image pages up to ~6× on reflowed history —
+  which flipped genuinely profitable history collapses to `not_profitable` and
+  left savings on the table. The gate now counts visual rows exactly as the
+  renderer wraps them.
 - **fix(factsheet):** capture transactional exact-token classes — email
   addresses, IBAN-like account strings, and currency amounts (`$14,360`). They
   join the protected tier-0 anchors (alongside SHAs, UUIDs, `CONST_IDS`, tickets,

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -1127,19 +1127,23 @@ function lineRows(line: string, cols: number): number {
   return Math.max(1, Math.ceil(line.length / cols));
 }
 
-/** Visual row count after soft-wrap at `cols`. Both `\n` and the ↵ sentinel
- *  end a row; ↵ occupies a cell on the line it terminates. */
+/** Visual row count after soft-wrap at `cols`.
+ *
+ *  Only hard `\n` starts a new row. The reflow ↵ sentinel is an inline glyph
+ *  (see reflow/wrapLines in render.ts: it never forces a row break), so packing
+ *  many original newlines into one soft-wrapped stream must NOT inflate the row
+ *  count. Treating ↵ as a break overstated image pages ~6× on reflowed history
+ *  and flipped profitable collapses to not_profitable. */
 function countVisualRows(text: string, cols: number): number {
   let rows = 0;
   let lineStart = 0;
   const len = text.length;
   for (let i = 0; i <= len; i++) {
     const cc = i < len ? text.charCodeAt(i) : -1;
-    const isSentinel = cc === 0x21b5 /* ↵ */;
-    if (i === len || cc === 10 /* \n */ || isSentinel) {
-      // ↵ renders as a glyph on the line it ends — count it in the length.
-      const lineLen = (isSentinel ? i + 1 : i) - lineStart;
-      rows += Math.max(1, Math.ceil(lineLen / cols));
+    if (i === len || cc === 10 /* \n */) {
+      const lineLen = i - lineStart;
+      // Empty line (consecutive \n) still costs one visual row.
+      rows += lineLen === 0 ? 1 : Math.ceil(lineLen / Math.max(1, cols));
       lineStart = i + 1;
     }
   }

--- a/tests/history.test.ts
+++ b/tests/history.test.ts
@@ -304,14 +304,12 @@ describe('collapseHistory', () => {
     expect(info.reason).toBe('prefix_too_short');
   });
 
-  it('rejects tiny histories under the full-canvas gate', async () => {
-    // 12 micro-turns (~150 chars serialised). Under the full-canvas render
-    // policy (no shrink-to-content) the cheapest image still spends the full
-    // 1568×88 pixel band, which costs more tokens than 150 chars of text. The
-    // gate correctly refuses unprofitable compressions — OmniGlyph must SAVE
-    // tokens, never spend more than the text it replaces. This is a regression
-    // guard against re-introducing shrink-to-content (which traded savings for
-    // a savings illusion on sparse content).
+  it('packs micro histories via reflow so the gate can accept them', async () => {
+    // 12 micro-turns. Reflow joins hard newlines with ↵ (inline glyph), so the
+    // serialised transcript is a short strip, not 40+ nearly-empty rows. The
+    // gate must use that same row model; treating ↵ as a break used to mark
+    // this unprofitable and skip collapse. Collapse is correct when the packed
+    // image is genuinely cheaper than the text it replaces.
     const msgs: Message[] = [];
     for (let i = 0; i < 12; i++) {
       msgs.push(i % 2 === 0 ? usr(`q${i}`) : asst(`a${i}`));
@@ -321,8 +319,9 @@ describe('collapseHistory', () => {
       minCollapsePrefix: 5,
       collapseChunk: 0,
     });
-    expect(info.reason).toBe('not_profitable');
-    expect(info.collapsedTurns).toBe(0);
+    expect(info.reason).toBeUndefined();
+    expect(info.collapsedTurns).toBe(12);
+    expect(info.collapsedImages).toBeGreaterThan(0);
   });
 
   it('collapses a long all-plain conversation into one prepended user message', async () => {

--- a/tests/paging.test.ts
+++ b/tests/paging.test.ts
@@ -74,6 +74,20 @@ describe('estimateImageCount', () => {
     expect(estimateImageCount(READABLE_CHARS_PER_IMAGE, COLS)).toBe(1);
     expect(estimateImageCount(READABLE_CHARS_PER_IMAGE + 1, COLS)).toBe(2);
   });
+
+  it('treats reflow ↵ as an inline glyph, not a row break', () => {
+    // reflow() packs "a↵b↵c" onto one soft-wrapped stream so short history
+    // lines PACK instead of each costing a near-empty row. The gate must count
+    // rows the same way the renderer wraps them; counting ↵ as a break
+    // overstated pages ~6× on reflowed history and blocked history collapse.
+    // Many short lines joined by ↵ stay one visual strip → one image.
+    const reflowed = Array.from({ length: ROWS_PER_IMG * 4 }, (_, i) => `t${i}`).join('↵');
+    expect(estimateImageCount(reflowed, COLS)).toBe(1);
+    // Control: the SAME lines with real newlines each cost one row, so
+    // ROWS_PER_IMG + 1 of them spill to a second image (↵ ≠ \n).
+    const raw = Array.from({ length: ROWS_PER_IMG + 1 }, (_, i) => `t${i}`).join('\n');
+    expect(estimateImageCount(raw, COLS)).toBe(2);
+  });
 });
 
 describe('dense readable render profile', () => {


### PR DESCRIPTION
## What

`countVisualRows` (the profitability-gate row estimator) treated the reflow `↵` sentinel (U+21B5) as a visual row break. But reflow packs hard newlines into one soft-wrapped stream where `↵` is an **inline glyph the renderer never breaks on**. Counting it as a break overstated image pages up to **~6×** on reflowed history, so `estimateImageCount` inflated the imaged cost and the gate flipped genuinely profitable history collapses to `not_profitable` — leaving token savings on the table (safe direction, but a real miss).

The fix counts visual rows exactly as the renderer wraps them: **only a hard `\n` starts a new row**; `↵` stays inline.

## Why it matters

Direct correctness fix to the exact-billing / profitability gate — the core value prop. No gate weakening: the gate still requires images < text; it just stops over-counting image cost.

## Tests (TDD)

- **RED first:** new `estimateImageCount` unit in `tests/paging.test.ts` — 360 short lines joined by `↵` must estimate to 1 image; failed on the buggy code (got 4).
- **Behavioral:** `tests/history.test.ts` — the former "rejects tiny histories … not_profitable" case now correctly **collapses** the 12 micro-turns (reason `undefined`, `collapsedTurns: 12`, `collapsedImages > 0`). The old assertion encoded the bug; updated to the corrected behavior (verified against real output, not masked).
- Full suite green: **941/941**, lint + typecheck + build clean.

## Attribution

Ported from an upstream commit by Steven Chong. Credit in the commit trailer (`Co-authored-by` + `Inspired-by`).