### PR TITLE
test(savings-math): pin OMNIGLYPH_MODELS so the e2e is hermetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic ver
 
 ### Changed
 
+- **test:** pin `OMNIGLYPH_MODELS` to the built-in default scope in the
+  savings-math e2e so the file is deterministic regardless of a developer's
+  ambient shell. The GPT cases drive `gpt-5.6`; a shell that exports a narrowed
+  `OMNIGLYPH_MODELS` (excluding GPT) previously made them fail on env alone.
+  Snapshot/set/restore, same convention as `proxy-usage.test.ts`. Assertions
+  unchanged.
 - **test:** raise the Vitest per-test timeout to 30s so genuinely slow render
   e2e cases (full reflow + PNG encode) are not false-negative timeouts on
   slower/CI machines. Assertions are unchanged. (thanks @ousamabenyounes)

--- a/tests/savings-math-e2e.test.ts
+++ b/tests/savings-math-e2e.test.ts
@@ -19,9 +19,25 @@
  *
  * Run just this file:  pnpm vitest run tests/savings-math-e2e.test.ts
  */
-import { describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { createProxy, type ProxyEvent } from '../src/core/proxy.js';
 import { countTokens as o200k } from 'gpt-tokenizer/encoding/o200k_base';
+
+// The GPT cases drive 'gpt-5.6', which is in the built-in default scope — but a
+// developer who exports OMNIGLYPH_MODELS in their shell (the documented way to
+// persist the scope) can narrow it to exclude GPT, at which point the proxy
+// stops imaging GPT and these assertions fail on ambient env alone. Pin the
+// scope to the built-in default so the file is deterministic regardless of the
+// shell (same snapshot/set/restore convention as proxy-usage.test.ts).
+let ambientModels: string | undefined;
+beforeAll(() => {
+  ambientModels = process.env.OMNIGLYPH_MODELS;
+  process.env.OMNIGLYPH_MODELS = 'claude-fable-5,gpt-5.6';
+});
+afterAll(() => {
+  if (ambientModels === undefined) delete process.env.OMNIGLYPH_MODELS;
+  else process.env.OMNIGLYPH_MODELS = ambientModels;
+});
 
 const PROBE_TOKENS = 9999; // canned count_tokens result from the fake upstream
 


### PR DESCRIPTION
## What

`tests/savings-math-e2e.test.ts` drives `gpt-5.6`. It's in the built-in default scope, so the file passes in a clean env — but a developer who **exports `OMNIGLYPH_MODELS`** in their shell (the documented way to persist the scope) can narrow it to exclude GPT. When that happens the proxy stops imaging GPT and 3 of the GPT assertions fail on ambient env alone, not on any real regression.

Fix: snapshot / set / restore `OMNIGLYPH_MODELS` to the built-in default (`claude-fable-5,gpt-5.6`) around the file, the same convention already used in `proxy-usage.test.ts`. **Assertions unchanged.**

## Verification

- Under a hostile ambient env (`OMNIGLYPH_MODELS=claude-fable-5`, GPT excluded): **8/8 pass** with the pin (was 3 failing without it).
- Clean env (`OMNIGLYPH_MODELS` unset): **8/8** (unchanged).
- Full suite: **940/940**; lint + typecheck + build clean.

## Attribution

Ported from an upstream commit by Steven Chong. Credit in the commit trailer (`Co-authored-by` + `Inspired-by`).