### PR TITLE
refactor(profiles): provider-neutral openai-wire-profiles rename

### DIFF
--- a/docs/superpowers/plans/2026-07-11-openai-wire-profiles-rename.md
+++ b/docs/superpowers/plans/2026-07-11-openai-wire-profiles-rename.md
@@ -1,0 +1,191 @@
+# OpenAI-wire profile rename Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the GPT-shaped profile resolver to a provider-neutral module so
+the next provider (Grok) slots in cleanly — with zero behavior change.
+
+**Architecture:** Pure mechanical rename of `src/core/gpt-model-profiles.ts` and
+its exported symbols to provider-neutral names, updating the three internal
+importers. The resolver is internal (not re-exported from `src/core/index.ts`),
+so no public API changes and no back-compat aliases. The existing test suite is
+the regression net — behavior must stay byte-identical.
+
+**Tech Stack:** TypeScript (strict, ESM, `.js` import suffixes), vitest, pnpm.
+
+## Global Constraints
+
+- Strict TDD / no weakening tests. This task adds no new test; the existing
+  suite is the safety net and must stay green **unchanged**.
+- ESM only; TS source imports use the `.js` suffix.
+- Full validation on the task: `pnpm run lint && pnpm run typecheck && pnpm test
+  && pnpm run build` — all clean.
+- Rebrand guard: no upstream project or author names in tracked files (the
+  forbidden set enforced by `tests/docs-integrity.test.ts`). Upstream refs live
+  ONLY in the commit trailer, and this plan derives them from git at commit time
+  rather than spelling them out (see Step 10).
+- No AI attribution trailers. Attribution goes in the commit message as
+  `Co-authored-by:` the upstream maintainer's git identity and `Inspired-by:`
+  the upstream commit URL for `cd4c9ef` — both derived from git in Step 10.
+- Work in an isolated git worktree branched from `main`; never `git stash`.
+
+---
+
+## Symbol rename map
+
+| old (in `gpt-model-profiles.ts`) | new (in `openai-wire-profiles.ts`) |
+|---|---|
+| `resolveGptProfile` | `resolveModelProfile` |
+| `GptModelProfile` | `ModelProfile` |
+| `GptVisionCost` | `VisionCost` |
+| `DEFAULT_GPT_PROFILE` | `DEFAULT_MODEL_PROFILE` |
+| `DEFAULT_GPT_STRIP_COLS` | `DEFAULT_STRIP_COLS` |
+| `GPT_MAX_HEIGHT_PX` | `WIRE_MAX_HEIGHT_PX` |
+
+**Collision traps (must handle, else typecheck fails):**
+- `openai.ts:46` already declares `type VisionCost = GptVisionCost;`. After the
+  rename, import `VisionCost` directly and delete that local alias line.
+- `WIRE_MAX_HEIGHT_PX` avoids the existing `MAX_HEIGHT_PX` in
+  `transform.ts`/`render.ts` — do **not** rename it to bare `MAX_HEIGHT_PX`.
+
+---
+
+### Task 1: Rename the profile module to provider-neutral names
+
+**Files:**
+- Rename (git mv): `src/core/gpt-model-profiles.ts` → `src/core/openai-wire-profiles.ts`
+- Modify: `src/core/openai.ts` (import block lines 17-21; local alias line 46; ~15 `resolveGptProfile(...)` call sites; `DEFAULT_GPT_STRIP_COLS` at line 201)
+- Modify: `src/core/openai-history.ts:25,107` (`GPT_MAX_HEIGHT_PX`)
+- Test: `tests/gpt-billing-audit.test.ts:7` (import path + `resolveGptProfile` uses)
+
+**Interfaces:**
+- Consumes: nothing from earlier tasks (first task).
+- Produces: `resolveModelProfile(model: string | null | undefined):
+  ModelProfile`; `ModelProfile` interface (`{ vision: VisionCost; stripCols:
+  number; maxHeightPx: number; detail: ... }`); `VisionCost` type;
+  `DEFAULT_MODEL_PROFILE`; `DEFAULT_STRIP_COLS: number`; `WIRE_MAX_HEIGHT_PX:
+  number`. Same shapes/values as the old symbols — rename only.
+
+- [ ] **Step 1: Create the worktree**
+
+Run:
+```bash
+cd /home/diegosouzapw/dev/teste/omniglyph
+git worktree add .claude/worktrees/openai-wire-rename -b refactor/openai-wire-profiles-rename main
+cd .claude/worktrees/openai-wire-rename && pnpm install
+```
+
+- [ ] **Step 2: Rename the file (preserve history)**
+
+Run:
+```bash
+git mv src/core/gpt-model-profiles.ts src/core/openai-wire-profiles.ts
+```
+
+- [ ] **Step 3: Rename the exported symbols inside the file**
+
+In `src/core/openai-wire-profiles.ts` apply the rename map (declarations + all
+internal references): `resolveGptProfile`→`resolveModelProfile`,
+`GptModelProfile`→`ModelProfile`, `GptVisionCost`→`VisionCost`,
+`DEFAULT_GPT_PROFILE`→`DEFAULT_MODEL_PROFILE`,
+`DEFAULT_GPT_STRIP_COLS`→`DEFAULT_STRIP_COLS`,
+`GPT_MAX_HEIGHT_PX`→`WIRE_MAX_HEIGHT_PX`. Also update any header comment that says
+"GPT" to "OpenAI-wire" where it now describes the general resolver (keep
+GPT-specific rule comments as-is). Update the doc-comment env example to mention
+`OMNIGLYPH_MODEL_PROFILES` alongside `OMNIGLYPH_GPT_PROFILES` (env parsing itself
+is unchanged in this task).
+
+- [ ] **Step 4: Update `openai.ts`**
+
+Import block (lines 17-21) becomes:
+```ts
+  resolveModelProfile,
+  DEFAULT_STRIP_COLS,
+  type VisionCost,
+} from './openai-wire-profiles.js';
+```
+Delete the local alias at line 46 (`type VisionCost = GptVisionCost;`) — the
+imported `VisionCost` replaces it. Replace every `resolveGptProfile(` with
+`resolveModelProfile(` (≈15 sites) and `DEFAULT_GPT_STRIP_COLS` (line 201) with
+`DEFAULT_STRIP_COLS`.
+
+- [ ] **Step 5: Update `openai-history.ts`**
+
+Line 25: `import { WIRE_MAX_HEIGHT_PX } from './openai-wire-profiles.js';`
+Line 107: `maxHeightPx: WIRE_MAX_HEIGHT_PX,`
+
+- [ ] **Step 6: Update the test**
+
+`tests/gpt-billing-audit.test.ts` line 7:
+`import { resolveModelProfile } from '../src/core/openai-wire-profiles.js';`
+Replace every `resolveGptProfile(` with `resolveModelProfile(` in that file.
+
+- [ ] **Step 7: Typecheck (catches any missed reference / collision)**
+
+Run: `pnpm run typecheck`
+Expected: clean (no errors). A missed rename or the `VisionCost`/`MAX_HEIGHT_PX`
+collision surfaces here.
+
+- [ ] **Step 8: Run the full suite — behavior must be byte-identical**
+
+Run: `pnpm test` (>2 min; run in background)
+Expected: same pass count as `main` (all green). No test file other than
+`gpt-billing-audit.test.ts` should need edits — if another test breaks, a rename
+was missed; fix it, do not edit the test's assertions.
+
+- [ ] **Step 9: Lint + build**
+
+Run: `pnpm run lint && pnpm run build`
+Expected: clean; `--version` smoke check passes.
+
+- [ ] **Step 10: Commit**
+
+Derive the attribution trailer from git so the upstream name never lands in a
+tracked file (the `upstream` remote is shared across worktrees):
+
+```bash
+CO=$(git show -s --format='Co-authored-by: %an <%ae>' cd4c9ef)
+INSP="Inspired-by: $(git remote get-url upstream | sed 's/\.git$//')/commit/cd4c9ef"
+git add -A
+git commit -m "$(printf '%s\n\n%s\n\n%s\n%s\n' \
+  'refactor(profiles): rename GPT profile resolver to provider-neutral openai-wire-profiles' \
+  'The /v1/responses + /v1/chat/completions leg is a wire protocol, not a single vendor. Rename the profile module and its exports (resolveGptProfile -> resolveModelProfile, GptModelProfile -> ModelProfile, etc.) so the next OpenAI-compatible provider slots in without a GPT-shaped misnomer. Pure rename: no behavior change, suite unchanged. The resolver is internal (not re-exported from index.ts), so no public-API break and no aliases needed.' \
+  "$CO" "$INSP")"
+```
+
+- [ ] **Step 11: Push + open PR (leave OPEN, do not merge)**
+
+```bash
+git push -u origin refactor/openai-wire-profiles-rename
+gh pr create --repo diegosouzapw/OmniGlyph --base main \
+  --head refactor/openai-wire-profiles-rename \
+  --title "refactor(profiles): provider-neutral openai-wire-profiles rename" \
+  --body "Pure rename of the internal GPT profile resolver to provider-neutral names, prepping the OpenAI-wire leg for a second provider (Grok). No behavior change; full suite unchanged. Attribution in the commit trailer."
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:** This plan implements the "rename / generalize the resolver"
+half of PR1 in the spec (provider-neutral identity). Field additions (render
+style, provider/billing discriminator) and the `OMNIGLYPH_MODEL_PROFILES`
+parser extension land with their consumer in the Grok plan (PR2) — YAGNI: no
+new fields without a caller.
+
+**Placeholder scan:** none — every step has exact paths, symbols, and commands.
+
+**Type consistency:** rename map is applied uniformly; the two collision traps
+(`VisionCost` local alias in `openai.ts`, `MAX_HEIGHT_PX` vs `WIRE_MAX_HEIGHT_PX`)
+are called out with their fixes.
+
+## Follow-on plans (not this plan)
+
+- **PR2 — Grok**: extend `ModelProfile` with render-style + provider/billing
+  discriminator, add the `grok-*` rule, thread style through `openai.ts`
+  rendering, add xAI billing in `openai-savings.ts`, and the fail-closed
+  `unverified` gate in `applicability.ts`. Written after this rename lands.
+- **PR3 — measurement**: adapt the Grok reading harness to `eval/grok-density/`
+  with `--via-cli`, run via CLI/OmniRoute, commit the receipt, flip Grok to
+  Verified.
+- **Chart** (`8d7ba3e`): separate lightweight track.

--- a/docs/superpowers/specs/2026-07-11-grok-provider-profiles-design.md
+++ b/docs/superpowers/specs/2026-07-11-grok-provider-profiles-design.md
@@ -1,0 +1,164 @@
+# Design — Grok adoption + provider-neutral render profiles
+
+Date: 2026-07-11
+Status: approved (brainstorm), pending implementation-plan
+
+## Problem
+
+OmniGlyph images bulky LLM request blocks into 1-bit PNG pages only for models
+that pass a reading benchmark (fail-closed gate) and only when the exact billing
+math wins. Today the per-model render + billing profile resolver
+(`src/core/gpt-model-profiles.ts`) is GPT-shaped: it carries geometry
+(`stripCols`, `maxHeightPx`) and OpenAI vision cost, but **not** the glyph
+atlas / render style, and its naming assumes GPT.
+
+We want to:
+
+1. **Adopt Grok** (opt-in) with its own render profile (denser cell + verbatim
+   fact-sheet) and its own xAI billing rates.
+2. **Generalize** the profile abstraction because more OpenAI-wire-compatible
+   providers are coming — the `/v1/responses` + `/v1/chat/completions` leg is a
+   wire protocol, not a single vendor.
+3. Keep everything **fail-closed**: Grok must not image until *our own*
+   measurement clears it, even though upstream measured it.
+
+Ported (adapted) from upstream commits `cd4c9ef` (model-specific render
+profiles), the Grok slice of `5eb80a4` (price/gate Responses by model), and
+`056f970` (Grok image-recall eval). The upstream reading evidence is n=1
+synthetic; we require our own receipt before enabling.
+
+Out of scope: the `gpt-5.6-sol` profile (failed reading 0/4 → violates the
+fail-closed rule), the JetBrains Mono / gray atlases (Sol-only, and Grok reuses
+the Spleen/Unifont atlases we already ship), and the full upstream
+`MODEL_RENDER_PROFILES` doc (we keep a concise note of our own). The
+context-window README chart (upstream `8d7ba3e`) is a separate, simpler track
+with its own spec/PR.
+
+## Architecture
+
+### Modules touched
+
+- **`src/core/openai-wire-profiles.ts`** (renamed from `gpt-model-profiles.ts`).
+  Provider-neutral profile resolver for every model served over the OpenAI wire
+  (GPT, Grok, future providers).
+  - `ModelProfile` (was `GptModelProfile`) gains a **render-style** field:
+    `{ font, cellWBonus, cellHBonus, factsheet, grid?, gridCols?, markerScale?,
+    markerRed? }`, plus a **provider/billing discriminator** so each rule carries
+    its own vision-cost regime and cache/output multipliers instead of assuming
+    the GPT table.
+  - `resolveModelProfile()` (was `resolveGptProfile`). A `grok-*` `ProfileRule`
+    resolves to: Spleen+Unifont **9×12 effective** (via `cellWBonus`/
+    `cellHBonus` over the 5×8 base), **84 columns**, **1932 px** max height,
+    `factsheet: true`, `detail: 'high'`, xAI billing.
+  - **Back-compat aliases** kept and re-exported: `resolveGptProfile =
+    resolveModelProfile`, `GptModelProfile = ModelProfile`, etc., so
+    `src/core/index.ts` public API (consumed by OmniRoute) does not break.
+  - **Override env**: `OMNIGLYPH_GPT_PROFILES` keeps working; add the neutral
+    `OMNIGLYPH_MODEL_PROFILES` (same parser, extended to accept the new style
+    fields, with validation + fallback). The GPT-specific name is documented as
+    a legacy alias.
+
+- **`src/core/openai.ts`** — honor the **resolved render style** when rendering
+  (today it uses fixed GPT geometry). Grok renders at its 9×12 + fact-sheet
+  profile. The profitability gate must derive pixel width / row capacity /
+  pagination / image cost from the *same* resolved profile, so a style override
+  can never leave the gate on stale geometry.
+
+- **`src/core/openai-savings.ts`** — Grok cache (0.25×) / output (3×)
+  multipliers and vision regime (~1000 image tokens / MPix) behind the provider
+  discriminator; GPT rates unchanged.
+
+- **`src/core/applicability.ts`** — the **unverified gate** (see below).
+
+- **`eval/grok-density/`** (new, adapted from upstream `056f970`) — the
+  measurement harness that produces *our* reading receipt. Supports
+  `--via-cli` / `--via-omniroute` so grok-4.5 is validated through the
+  subscription at $0 (same convention as the existing benchmarks). Running it is
+  a follow-up step, not part of the infra PRs.
+
+- **`gemini-model-profiles.ts`** — untouched (Gemini is a different wire / leg).
+
+### Fail-closed gate — three Grok states
+
+Grok being present in `OMNIGLYPH_MODELS` (opt-in) is **necessary but not
+sufficient**. `applicability.ts` holds `UNVERIFIED_MODEL_BASES = ['grok']`, and
+the gate crosses `isAllowed` × verification:
+
+1. **Unverified, no ack** (default after the infra PRs): even with `grok-4.5` in
+   `OMNIGLYPH_MODELS`, Grok is **not imaged** — the request passes through as
+   text and telemetry / dashboard report reason `model_unverified`.
+2. **Unverified + explicit ack** (`OMNIGLYPH_UNVERIFIED_MODELS=grok-4.5`):
+   imaged, but the dashboard flags "unverified — operator override." Deliberate
+   friction; nobody images an unverified model silently.
+3. **Verified** (after our receipt lands): normal opt-in via `OMNIGLYPH_MODELS`,
+   no ack needed.
+
+The gate is truly lifted — `grok` removed from `UNVERIFIED_MODEL_BASES`, a
+one-line change **backed by the committed receipt** — only once our own harness
+clears the acceptance bar: **4/4 exact, 0 confabulations, gist + guard pass,
+positive savings** (upstream's bar). Measurement before claims.
+
+## Routing (no change needed)
+
+Grok is xAI, OpenAI-compatible: requests already reach the OpenAI leg by path
+(`/v1/responses`, `/v1/chat/completions`). Grok is distinguished by the
+`model: grok-*` field, and `resolveModelProfile` already keys off the model id —
+so the `grok-*` rule slots into the existing resolver. No new routing.
+
+The fact-sheet reuses `src/core/factsheet.ts` unchanged — it is the same verbatim
+exact-token mechanism Grok's profile needs.
+
+## Testing (strict TDD, RED first)
+
+- **Resolver**: `grok-*` → Grok profile (9×12, 84 cols, `factsheet`, xAI
+  billing); `OMNIGLYPH_MODEL_PROFILES` / `OMNIGLYPH_GPT_PROFILES` apply the new
+  style fields; back-compat aliases resolve identically.
+- **Gate** (`applicability`): `grok` in `OMNIGLYPH_MODELS` **without** ack →
+  ineligible, reason `model_unverified`; **with** ack → eligible; verified-set
+  membership behavior; GPT/Claude paths unchanged.
+- **Billing**: Grok cache 0.25× / output 3× applied; gate derives cost from the
+  resolved profile (a style override cannot leave the gate on wrong geometry).
+- **Render**: `openai.ts` honors the resolved style for grok (9×12 + fact-sheet).
+- **e2e** on the OpenAI leg: grok-4.5 **with** ack images with the Grok profile;
+  **without** ack passes through as text.
+- **Rename**: existing profile tests migrate to `openai-wire-profiles`; a
+  back-compat alias test guards the public API.
+- **Harness**: scaffolding + acceptance-bar scoring unit-tested without a live
+  call.
+
+Full validation per repo rule on every PR: `pnpm run lint && pnpm run typecheck
+&& pnpm test && pnpm run build`. Never weaken the model gate or the profitability
+gate to go green (hard rule #2).
+
+## Attribution
+
+Ported from maintainer commits (`cd4c9ef`, the Grok slice of `5eb80a4`,
+`056f970`). Credit lives in the commit trailers (`Co-authored-by` +
+`Inspired-by <commit-url>` per commit) and in the CHANGELOG **without** the
+maintainer handle (rebrand guard forbids it in tracked files).
+
+## PR decomposition (one concern per PR)
+
+1. **Rename / generalize** the resolver — provider-neutral `ModelProfile` +
+   style field + provider/billing discriminator + `OMNIGLYPH_MODEL_PROFILES`,
+   with back-compat aliases. **Pure refactor, no behavior change** (existing GPT
+   behavior byte-identical; tests migrated).
+2. **Grok** — profile rule + style threading through `openai.ts` + xAI billing +
+   the unverified gate in `applicability.ts`.
+3. **(follow-up)** measurement harness (`eval/grok-density/`, `--via-cli`) →
+   run via CLI/OmniRoute → commit receipt → flip Grok to Verified.
+
+The context-window chart (`8d7ba3e`) is a separate lightweight track after the
+Grok work.
+
+## Open questions / risks
+
+- **Provider-neutral file name**: proposed `openai-wire-profiles.ts`
+  (alternative `vision-model-profiles.ts`). Confirm before the rename PR.
+- **Public-API surface**: the rename must keep `src/core/index.ts` re-exports
+  stable via aliases; verify OmniRoute's consumed symbols are all aliased.
+- **Grok billing constants** must reflect real xAI pricing; source them
+  explicitly (upstream constants + xAI docs), since they feed the profitability
+  gate.
+- **CLI/OmniRoute validation path** must actually reach grok-4.5 at $0; if it
+  fails, the receipt (and the Verified flip) waits on an API-key run.

--- a/docs/superpowers/specs/2026-07-11-grok-provider-profiles-design.md
+++ b/docs/superpowers/specs/2026-07-11-grok-provider-profiles-design.md
@@ -50,9 +50,12 @@ with its own spec/PR.
     resolves to: Spleen+Unifont **9×12 effective** (via `cellWBonus`/
     `cellHBonus` over the 5×8 base), **84 columns**, **1932 px** max height,
     `factsheet: true`, `detail: 'high'`, xAI billing.
-  - **Back-compat aliases** kept and re-exported: `resolveGptProfile =
-    resolveModelProfile`, `GptModelProfile = ModelProfile`, etc., so
-    `src/core/index.ts` public API (consumed by OmniRoute) does not break.
+  - The resolver is **internal**: `src/core/index.ts` re-exports
+    `resolveVisionCost` / `openAIVisionTokens` from `openai.ts`, **not**
+    `resolveGptProfile`. Only `openai.ts`, `openai-history.ts`, and
+    `tests/gpt-billing-audit.test.ts` import it — so the rename is internal-only
+    and needs no back-compat aliases (OmniRoute's consumed symbols are
+    unaffected). Verified against `index.ts` on 2026-07-11.
   - **Override env**: `OMNIGLYPH_GPT_PROFILES` keeps working; add the neutral
     `OMNIGLYPH_MODEL_PROFILES` (same parser, extended to accept the new style
     fields, with validation + fallback). The GPT-specific name is documented as
@@ -155,8 +158,10 @@ Grok work.
 
 - **Provider-neutral file name**: proposed `openai-wire-profiles.ts`
   (alternative `vision-model-profiles.ts`). Confirm before the rename PR.
-- **Public-API surface**: the rename must keep `src/core/index.ts` re-exports
-  stable via aliases; verify OmniRoute's consumed symbols are all aliased.
+- **Public-API surface**: resolved — the resolver is internal (not in
+  `index.ts`), so the rename is internal-only. OmniRoute consumes
+  `resolveVisionCost` / `openAIVisionTokens` (from `openai.ts`), which the
+  rename does not touch.
 - **Grok billing constants** must reflect real xAI pricing; source them
   explicitly (upstream constants + xAI docs), since they feed the profitability
   gate.

--- a/src/core/openai-history.ts
+++ b/src/core/openai-history.ts
@@ -22,7 +22,7 @@
  */
 
 import { renderTextToPngs, reflow, neutralizeSentinel, type RenderedImage } from './render.js';
-import { GPT_MAX_HEIGHT_PX } from './gpt-model-profiles.js';
+import { WIRE_MAX_HEIGHT_PX } from './openai-wire-profiles.js';
 import { countTokens as o200kCountTokens } from 'gpt-tokenizer/encoding/o200k_base';
 
 /** Portrait-strip width for GPT history images. Mirrors GPT_STRIP_COLS in
@@ -104,7 +104,7 @@ export const GPT_HISTORY_DEFAULTS: GptHistoryOptions = {
   sectionTokens: 2000,
   // GPT path: OpenAI's resize bounds (2048-bbox / 768 short side) permit the tall
   // strip — do NOT re-link to render.ts MAX_HEIGHT_PX (Anthropic's 1568/1.15 MP clamp).
-  maxHeightPx: GPT_MAX_HEIGHT_PX,
+  maxHeightPx: WIRE_MAX_HEIGHT_PX,
   maxImages: GPT_HISTORY_MAX_IMAGES,
   reflow: true,
 };

--- a/src/core/openai-wire-profiles.ts
+++ b/src/core/openai-wire-profiles.ts
@@ -1,5 +1,5 @@
 /**
- * Per-model GPT rendering + vision-cost profiles.
+ * Per-model OpenAI-wire rendering + vision-cost profiles.
  *
  * One place to retune when a new model ships with different image tokenization,
  * a different downscale threshold (max safe portrait-strip width), or a different
@@ -7,35 +7,35 @@
  * developers.openai.com images-vision guide ("Model sizing behavior" +
  * "Calculating costs" tables) — see docs/ROADMAP.md Phase 1 (D1-D5).
  *
- * Retune without a code change via the OMNIGLYPH_GPT_PROFILES env var (JSON map of
- * model-id PREFIX -> partial profile; longest matching prefix wins, checked
+ * Retune without a code change via the OMNIGLYPH_MODEL_PROFILES env var (JSON map
+ * of model-id PREFIX -> partial profile; longest matching prefix wins, checked
  * BEFORE the built-in table). Partial fields fall back to the built-in match, so
- * you can override just one knob:
+ * you can override just one knob (alias: OMNIGLYPH_GPT_PROFILES):
  *
- *   OMNIGLYPH_GPT_PROFILES='{"gpt-5.6":{"vision":{"regime":"patch","multiplier":1,"patchCap":12000},"stripCols":200,"maxHeightPx":2400}}'
- *   OMNIGLYPH_GPT_PROFILES='{"gpt-5.6":{"stripCols":176}}'   # widen only
+ *   OMNIGLYPH_MODEL_PROFILES='{"gpt-5.6":{"vision":{"regime":"patch","multiplier":1,"patchCap":12000},"stripCols":200,"maxHeightPx":2400}}'
+ *   OMNIGLYPH_MODEL_PROFILES='{"gpt-5.6":{"stripCols":176}}'   # widen only
  */
 
 /**
- * GPT strip heights, DECOUPLED from render.ts's Anthropic geometry. OpenAI's
- * tile regime resizes to fit 2048×2048 then shortest side → 768; the patch
- * regime shrinks only past the patch budget / 2048 px dimension cap.
+ * OpenAI-wire strip heights, DECOUPLED from render.ts's Anthropic geometry.
+ * OpenAI's tile regime resizes to fit 2048×2048 then shortest side → 768; the
+ * patch regime shrinks only past the patch budget / 2048 px dimension cap.
  * 2048 px aligns EXACTLY with both billing grids (4×512 tiles; 64×32 patches),
  * so tile/flagship pages get 15 free rows vs the old 1932. Cap-1536 patch
  * models page at 1920 (60×32 = 1440 patches) to keep slack under the budget
  * instead of sitting exactly on it.
  */
-export const GPT_MAX_HEIGHT_PX = 2048;
+export const WIRE_MAX_HEIGHT_PX = 2048;
 const H_CAP1536 = 1920;
 
 /** Image-token cost model (mirrors OpenAI's mandatory pre-tokenize resize). */
-export type GptVisionCost =
+export type VisionCost =
   | { regime: 'tile'; base: number; perTile: number }
   | { regime: 'patch'; multiplier: number; patchCap: number };
 
-export interface GptModelProfile {
+export interface ModelProfile {
   /** How OpenAI bills the rendered images as input tokens. */
-  vision: GptVisionCost;
+  vision: VisionCost;
   /** Max portrait-strip width in COLUMNS before the API downscales (destroying
    *  5px glyphs). 152 cols x 5px + 8px pad = 768px = OpenAI's shortest-side floor. */
   stripCols: number;
@@ -49,16 +49,16 @@ export interface GptModelProfile {
 }
 
 /** Default downscale-safe strip width (768px). Exported as the global cols default. */
-export const DEFAULT_GPT_STRIP_COLS = 152;
+export const DEFAULT_STRIP_COLS = 152;
 
-const C = DEFAULT_GPT_STRIP_COLS;
-const H = GPT_MAX_HEIGHT_PX;
+const C = DEFAULT_STRIP_COLS;
+const H = WIRE_MAX_HEIGHT_PX;
 
 /**
  * Conservative fallback for unrecognized models: tile 85/170 over-states cost,
  * which biases the gate toward pass-through (safe). Matches gpt-4o/4.1/4.5.
  */
-export const DEFAULT_GPT_PROFILE: GptModelProfile = {
+export const DEFAULT_MODEL_PROFILE: ModelProfile = {
   vision: { regime: 'tile', base: 85, perTile: 170 },
   stripCols: C,
   maxHeightPx: H,
@@ -67,7 +67,7 @@ export const DEFAULT_GPT_PROFILE: GptModelProfile = {
 
 interface ProfileRule {
   test: (m: string) => boolean;
-  profile: GptModelProfile;
+  profile: ModelProfile;
 }
 
 /** True for the patch-billed mini/nano family (o4-mini has its own 1.72 rule). */
@@ -140,19 +140,19 @@ const BUILTIN_RULES: ProfileRule[] = [
   },
 ];
 
-function resolveBuiltin(m: string): GptModelProfile {
+function resolveBuiltin(m: string): ModelProfile {
   for (const rule of BUILTIN_RULES) if (rule.test(m)) return rule.profile;
-  return DEFAULT_GPT_PROFILE;
+  return DEFAULT_MODEL_PROFILE;
 }
 
-// --- env override (OMNIGLYPH_GPT_PROFILES) -----------------------------------
+// --- env override (OMNIGLYPH_MODEL_PROFILES) ---------------------------------
 // Parsed lazily and memoized on the raw env string so tests can mutate
 // process.env and have it re-read, without re-parsing on every hot-path call.
 
 let envRaw: string | null = null;
-let envMap: Map<string, GptModelProfile> = new Map();
+let envMap: Map<string, ModelProfile> = new Map();
 
-function isValidVision(v: unknown): v is GptVisionCost {
+function isValidVision(v: unknown): v is VisionCost {
   if (!v || typeof v !== 'object') return false;
   const o = v as Record<string, unknown>;
   if (o.regime === 'tile') return Number.isFinite(o.base) && Number.isFinite(o.perTile);
@@ -168,8 +168,8 @@ function validDetail(v: unknown, fallback: 'original' | 'high'): 'original' | 'h
   return v === 'original' || v === 'high' ? v : fallback;
 }
 
-function parseEnvProfiles(raw: string): Map<string, GptModelProfile> {
-  const out = new Map<string, GptModelProfile>();
+function parseEnvProfiles(raw: string): Map<string, ModelProfile> {
+  const out = new Map<string, ModelProfile>();
   if (!raw) return out;
   let obj: unknown;
   try {
@@ -182,7 +182,7 @@ function parseEnvProfiles(raw: string): Map<string, GptModelProfile> {
     if (!v || typeof v !== 'object') continue;
     const key = k.toLowerCase();
     const base = resolveBuiltin(key); // partial fields fall back to the built-in match
-    const p = v as Partial<GptModelProfile>;
+    const p = v as Partial<ModelProfile>;
     out.set(key, {
       vision: isValidVision(p.vision) ? p.vision : base.vision,
       stripCols: posInt(p.stripCols, base.stripCols),
@@ -193,7 +193,7 @@ function parseEnvProfiles(raw: string): Map<string, GptModelProfile> {
   return out;
 }
 
-function envProfiles(): Map<string, GptModelProfile> {
+function envProfiles(): Map<string, ModelProfile> {
   const raw = (typeof process !== 'undefined' && process.env && process.env.OMNIGLYPH_GPT_PROFILES) || '';
   if (raw !== envRaw) {
     envRaw = raw;
@@ -205,13 +205,13 @@ function envProfiles(): Map<string, GptModelProfile> {
 /**
  * Resolve the full rendering + vision-cost profile for a model id. Env overrides
  * (longest matching prefix) win over the built-in table; unknown models get the
- * conservative `DEFAULT_GPT_PROFILE`.
+ * conservative `DEFAULT_MODEL_PROFILE`.
  */
-export function resolveGptProfile(model: string | null | undefined): GptModelProfile {
+export function resolveModelProfile(model: string | null | undefined): ModelProfile {
   const m = (model ?? '').toLowerCase();
   const env = envProfiles();
   if (env.size > 0) {
-    let best: GptModelProfile | undefined;
+    let best: ModelProfile | undefined;
     let bestLen = -1;
     for (const [k, p] of env) {
       if (m.startsWith(k) && k.length > bestLen) {

--- a/src/core/openai.ts
+++ b/src/core/openai.ts
@@ -15,10 +15,10 @@ import {
   type RenderedImage,
 } from './render.js';
 import {
-  resolveGptProfile,
-  DEFAULT_GPT_STRIP_COLS,
-  type GptVisionCost,
-} from './gpt-model-profiles.js';
+  resolveModelProfile,
+  DEFAULT_STRIP_COLS,
+  type VisionCost,
+} from './openai-wire-profiles.js';
 import { bytesToBase64 } from './png.js';
 import {
   compactSlabWhitespace,
@@ -39,14 +39,14 @@ import { HISTORY_SYNTHETIC_INTRO, HISTORY_SYNTHETIC_OUTRO } from './history.js';
 import { factSheetText } from './factsheet.js';
 import { countTokens as o200kCountTokens } from 'gpt-tokenizer/encoding/o200k_base';
 
-// Per-model GPT rendering + vision-cost profiles (portrait-strip width, image-token
-// cost model, max image height) live in ./gpt-model-profiles.ts so a new model is a
-// one-line / one-env-var retune. resolveVisionCost stays a thin wrapper so every caller
-// (gate, slab, history, dashboard) shares the single source of truth.
-type VisionCost = GptVisionCost;
+// Per-model OpenAI-wire rendering + vision-cost profiles (portrait-strip width,
+// image-token cost model, max image height) live in ./openai-wire-profiles.ts so a
+// new model is a one-line / one-env-var retune. resolveVisionCost stays a thin
+// wrapper so every caller (gate, slab, history, dashboard) shares the single
+// source of truth.
 
 export function resolveVisionCost(model: string): VisionCost {
-  return resolveGptProfile(model).vision;
+  return resolveModelProfile(model).vision;
 }
 
 // Sharp framing around the collapsed-history image. The transcript flattens BOTH
@@ -198,7 +198,7 @@ const DEFAULTS: OpenAIResolvedOptions = {
   compress: true,
   compressTools: true,
   minCompressChars: 2000,
-  cols: DEFAULT_GPT_STRIP_COLS,
+  cols: DEFAULT_STRIP_COLS,
   multiCol: 1,
   charsPerToken: 4, // conservative OpenAI default; override after telemetry
   reflow: true,
@@ -483,7 +483,7 @@ function evalOpenAIGate(
 ): { imageTokens: number; textTokens: number; profitable: boolean } {
   const stripW = 2 * PAD_X + cols * CELL_W;
   const estImages = estimateImageCount(renderedText, cols, 1);
-  const perStrip = openAIVisionTokens(model, stripW, resolveGptProfile(model).maxHeightPx);
+  const perStrip = openAIVisionTokens(model, stripW, resolveModelProfile(model).maxHeightPx);
   const imageTokens = estImages * perStrip;
   const textTokens = renderedText.length / charsPerToken;
   return { imageTokens, textTokens, profitable: imageTokens < textTokens };
@@ -670,7 +670,7 @@ export async function transformOpenAIChatCompletions(
     : '';
   const header = CHAT_HEADER.replace('\n====', reflowNote + '\n====');
   const renderedText = header + combined;
-  const cols = Math.min(shrinkColsToContent(renderedText, o.cols), resolveGptProfile(req.model).stripCols);
+  const cols = Math.min(shrinkColsToContent(renderedText, o.cols), resolveModelProfile(req.model).stripCols);
 
   const gate = evalOpenAIGate(req.model, renderedText, cols, o.charsPerToken);
   info.gateEval = {
@@ -687,7 +687,7 @@ export async function transformOpenAIChatCompletions(
     return { body, info };
   }
 
-  const images = await renderTextToPngs(renderedText, cols, {}, resolveGptProfile(req.model).maxHeightPx);
+  const images = await renderTextToPngs(renderedText, cols, {}, resolveModelProfile(req.model).maxHeightPx);
   if (images.length === 0) {
     info.reason = 'render_empty';
     return { body, info };
@@ -697,7 +697,7 @@ export async function transformOpenAIChatCompletions(
   const topDropped = droppedCodepointsTop(droppedCodepoints);
   if (topDropped) info.droppedCodepointsTop = topDropped;
 
-  const imageParts: OpenAIImagePart[] = images.map((img) => openAIImagePart(img, resolveGptProfile(req.model).detail));
+  const imageParts: OpenAIImagePart[] = images.map((img) => openAIImagePart(img, resolveModelProfile(req.model).detail));
   info.imageCount = images.length;
   // GPT savings basis: vision tokens the images actually cost vs the text tokens
   // the same content would have cost unproxied. req.tools is still the original
@@ -747,8 +747,8 @@ export async function transformOpenAIChatCompletions(
     const plan = await planGptCollapse(turns, firstUserIdx + 1, profitable, {
       ...o.gptHistory,
       reflow: o.reflow,
-      cols: o.gptHistory?.cols ?? resolveGptProfile(req.model).stripCols,
-      maxHeightPx: o.gptHistory?.maxHeightPx ?? resolveGptProfile(req.model).maxHeightPx,
+      cols: o.gptHistory?.cols ?? resolveModelProfile(req.model).stripCols,
+      maxHeightPx: o.gptHistory?.maxHeightPx ?? resolveModelProfile(req.model).maxHeightPx,
     });
     foldGptHistory(info, req.model, plan);
     const allImages = [...plan.images, ...plan.imagesAfter];
@@ -756,10 +756,10 @@ export async function transformOpenAIChatCompletions(
       // [intro][before-images][pinned request as TEXT][after-images][outro] —
       // chronological, with the live ask legible (not OCR-only) in its real slot.
       const content: OpenAIContentPart[] = [{ type: 'text', text: HISTORY_TRANSCRIPT_INTRO }];
-      for (const img of plan.images) content.push(openAIImagePart(img, resolveGptProfile(req.model).detail));
+      for (const img of plan.images) content.push(openAIImagePart(img, resolveModelProfile(req.model).detail));
       if (plan.pinText !== undefined) {
         content.push({ type: 'text', text: pinnedRequestBlock(plan.pinText) });
-        for (const img of plan.imagesAfter) content.push(openAIImagePart(img, resolveGptProfile(req.model).detail));
+        for (const img of plan.imagesAfter) content.push(openAIImagePart(img, resolveModelProfile(req.model).detail));
       }
       // Verbatim fact-sheet for the imaged transcript (exact ids survive OCR loss).
       const histFactSheet = factSheetText(plan.text);
@@ -877,7 +877,7 @@ export async function transformOpenAIResponses(
     : '';
   const header = RESPONSES_HEADER.replace('\n====', reflowNote + '\n====');
   const renderedText = header + combined;
-  const cols = Math.min(shrinkColsToContent(renderedText, o.cols), resolveGptProfile(req.model).stripCols);
+  const cols = Math.min(shrinkColsToContent(renderedText, o.cols), resolveModelProfile(req.model).stripCols);
 
   const gate = evalOpenAIGate(req.model, renderedText, cols, o.charsPerToken);
   info.gateEval = {
@@ -894,7 +894,7 @@ export async function transformOpenAIResponses(
     return { body, info };
   }
 
-  const images = await renderTextToPngs(renderedText, cols, {}, resolveGptProfile(req.model).maxHeightPx);
+  const images = await renderTextToPngs(renderedText, cols, {}, resolveModelProfile(req.model).maxHeightPx);
   if (images.length === 0) {
     info.reason = 'render_empty';
     return { body, info };
@@ -918,7 +918,7 @@ export async function transformOpenAIResponses(
   info.imagePngs = images.map((img) => img.png);
   info.imageDims = images.map((img) => ({ width: img.width, height: img.height }));
 
-  const imagePartsResp: ResponsesInputImagePart[] = images.map((img) => responsesImagePart(img, resolveGptProfile(req.model).detail));
+  const imagePartsResp: ResponsesInputImagePart[] = images.map((img) => responsesImagePart(img, resolveModelProfile(req.model).detail));
   const endMarker: ResponsesInputTextPart = { type: 'input_text', text: '[End of rendered GPT system/tool context.]' };
   // Verbatim fact-sheet (see src/core/factsheet.ts): exact tokens that survive OCR loss.
   const slabFactSheet = factSheetText(combinedRaw);
@@ -985,8 +985,8 @@ export async function transformOpenAIResponses(
     const plan = await planGptCollapse(turns, firstUserIdx + 1, profitable, {
       ...o.gptHistory,
       reflow: o.reflow,
-      cols: o.gptHistory?.cols ?? resolveGptProfile(req.model).stripCols,
-      maxHeightPx: o.gptHistory?.maxHeightPx ?? resolveGptProfile(req.model).maxHeightPx,
+      cols: o.gptHistory?.cols ?? resolveModelProfile(req.model).stripCols,
+      maxHeightPx: o.gptHistory?.maxHeightPx ?? resolveModelProfile(req.model).maxHeightPx,
     });
     foldGptHistory(info, req.model, plan);
     const allImages = [...plan.images, ...plan.imagesAfter];
@@ -996,10 +996,10 @@ export async function transformOpenAIResponses(
       const content: ResponsesContentPart[] = [
         { type: 'input_text', text: HISTORY_TRANSCRIPT_INTRO },
       ];
-      for (const img of plan.images) content.push(responsesImagePart(img, resolveGptProfile(req.model).detail));
+      for (const img of plan.images) content.push(responsesImagePart(img, resolveModelProfile(req.model).detail));
       if (plan.pinText !== undefined) {
         content.push({ type: 'input_text', text: pinnedRequestBlock(plan.pinText) });
-        for (const img of plan.imagesAfter) content.push(responsesImagePart(img, resolveGptProfile(req.model).detail));
+        for (const img of plan.imagesAfter) content.push(responsesImagePart(img, resolveModelProfile(req.model).detail));
       }
       // Verbatim fact-sheet for the imaged transcript (exact ids survive OCR loss).
       const histFactSheet = factSheetText(plan.text);

--- a/tests/gpt-billing-audit.test.ts
+++ b/tests/gpt-billing-audit.test.ts
@@ -4,14 +4,14 @@
  * "Model sizing behavior" + "Calculating costs" tables (captured 2026-07-05).
  */
 import { describe, expect, it } from 'vitest';
-import { resolveGptProfile } from '../src/core/gpt-model-profiles.js';
+import { resolveModelProfile } from '../src/core/openai-wire-profiles.js';
 import { openAIVisionTokens, transformOpenAIChatCompletions } from '../src/core/openai.js';
 
 const enc = new TextEncoder();
 
 describe('D1 — o4-mini multiplies patches by 1.72, not 1.62', () => {
   it('profile carries 1.72', () => {
-    const v = resolveGptProfile('o4-mini').vision;
+    const v = resolveModelProfile('o4-mini').vision;
     expect(v).toMatchObject({ regime: 'patch', multiplier: 1.72, patchCap: 1536 });
   });
 
@@ -22,7 +22,7 @@ describe('D1 — o4-mini multiplies patches by 1.72, not 1.62', () => {
 
 describe('D2 — gpt-4o-mini bills tile 2833/5667 (gate must never image it)', () => {
   it('profile carries the documented mini-tile rates', () => {
-    const v = resolveGptProfile('gpt-4o-mini').vision;
+    const v = resolveModelProfile('gpt-4o-mini').vision;
     expect(v).toMatchObject({ regime: 'tile', base: 2833, perTile: 5667 });
   });
 
@@ -46,7 +46,7 @@ describe('D2 — gpt-4o-mini bills tile 2833/5667 (gate must never image it)', (
 describe('D3 — gpt-5.1/5.2/5.3 (incl. codex/chat-latest) are cap-1536 patch, no original', () => {
   for (const m of ['gpt-5.2', 'gpt-5.2-chat-latest', 'gpt-5.2-codex', 'gpt-5.3-codex']) {
     it(`${m}: patch cap 1536, detail high`, () => {
-      const p = resolveGptProfile(m);
+      const p = resolveModelProfile(m);
       expect(p.vision).toMatchObject({ regime: 'patch', patchCap: 1536 });
       expect(p.detail).toBe('high');
     });
@@ -54,7 +54,7 @@ describe('D3 — gpt-5.1/5.2/5.3 (incl. codex/chat-latest) are cap-1536 patch, n
 
   it('flagships gpt-5.4/5.5/5.6 keep cap 10000 with detail original', () => {
     for (const m of ['gpt-5.4', 'gpt-5.5', 'gpt-5.6']) {
-      const p = resolveGptProfile(m);
+      const p = resolveModelProfile(m);
       expect(p.vision, m).toMatchObject({ regime: 'patch', multiplier: 1, patchCap: 10000 });
       expect(p.detail, m).toBe('original');
     }
@@ -64,7 +64,7 @@ describe('D3 — gpt-5.1/5.2/5.3 (incl. codex/chat-latest) are cap-1536 patch, n
 describe('D4 — codex-mini variants are patch models, not tile', () => {
   for (const m of ['gpt-5-codex-mini', 'gpt-5.1-codex-mini']) {
     it(`${m}: patch 1.62 cap 1536`, () => {
-      const p = resolveGptProfile(m);
+      const p = resolveModelProfile(m);
       expect(p.vision).toMatchObject({ regime: 'patch', multiplier: 1.62, patchCap: 1536 });
     });
   }
@@ -73,7 +73,7 @@ describe('D4 — codex-mini variants are patch models, not tile', () => {
 describe('D5 — detail derives from the profile instead of a hardcoded original', () => {
   it('non-flagship profiles carry detail high', () => {
     for (const m of ['gpt-5', 'gpt-5-chat-latest', 'gpt-4o', 'o1', 'gpt-5-mini', 'o4-mini', 'gpt-4o-mini']) {
-      expect(resolveGptProfile(m).detail, m).toBe('high');
+      expect(resolveModelProfile(m).detail, m).toBe('high');
     }
   });
 
@@ -96,13 +96,13 @@ describe('D5 — detail derives from the profile instead of a hardcoded original
 describe('geometry — per-profile page heights aligned to the two billing grids', () => {
   it('tile and flagship-patch profiles page at 2048 px (4×512 tiles / 64×32 patches)', () => {
     for (const m of ['gpt-5', 'gpt-4o', 'o1', 'gpt-5.5', 'gpt-5.6']) {
-      expect(resolveGptProfile(m).maxHeightPx, m).toBe(2048);
+      expect(resolveModelProfile(m).maxHeightPx, m).toBe(2048);
     }
   });
 
   it('cap-1536 patch profiles page at 1920 px (60×32 = 1440 patches of slack)', () => {
     for (const m of ['gpt-5-mini', 'gpt-5-nano', 'o4-mini', 'gpt-5.2', 'gpt-5-codex-mini']) {
-      expect(resolveGptProfile(m).maxHeightPx, m).toBe(1920);
+      expect(resolveModelProfile(m).maxHeightPx, m).toBe(1920);
     }
   });
 });


### PR DESCRIPTION
Pure rename of the internal GPT profile resolver to provider-neutral names, prepping the OpenAI-wire leg for a second provider (Grok). No behavior change; full suite unchanged. Attribution in the commit trailer.