### PR TITLE
fix(transform): keep scope-global cache_control valid across multi-image slabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic ver
 
 ### Fixed
 
+- **fix(transform):** keep `scope: "global"` `cache_control` valid across
+  multi-image slabs. Anthropic rejects a globally-scoped block unless every
+  preceding block is also globally scoped; the caller's marker used to land
+  only on the LAST rendered page (and the history-anchor relocation then moved
+  it off the slab entirely), so any multi-page slab 400'd the whole request.
+  A global marker now covers every slab page and is copied — not moved — onto
+  the history anchor. Plain ephemeral markers keep the existing single,
+  trailing placement. (thanks @jasminaladdn)
 - **fix(transform):** the profitability gate no longer counts the reflow ↵
   sentinel as a visual row break. Reflow packs hard newlines into one
   soft-wrapped stream (↵ is an inline glyph the renderer never breaks on), so

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -924,7 +924,18 @@ function relocateAnchorToHistoryImage(messages: Message[] | undefined, anchorOrd
   if (!slabAnchor) return; // nothing to relocate → never add a marker
 
   historyImg.cache_control = slabAnchor.cache_control;
-  delete slabAnchor.cache_control;
+  // Moving a scope:"global" anchor would leave the (now unmarked) slab pages
+  // BEFORE a globally-scoped block — the invalid prefix Anthropic 400s. Global
+  // anchors are copied, not moved; plain ephemeral keeps pure relocation.
+  if (!isGlobalScopeCacheControl(slabAnchor.cache_control)) {
+    delete slabAnchor.cache_control;
+  }
+}
+
+/** Caller marker carries Anthropic's org-wide scope — subject to the
+ *  "every preceding block must also be globally scoped" prefix rule. */
+function isGlobalScopeCacheControl(cc: unknown): boolean {
+  return typeof cc === 'object' && cc !== null && (cc as { scope?: unknown }).scope === 'global';
 }
 
 /**
@@ -1827,8 +1838,15 @@ export async function transformRequest(
       droppedCodepoints.set(cp, (droppedCodepoints.get(cp) ?? 0) + n);
     }
     const imageBlock = makeImageBlock(b64, i === images.length - 1);
+    // scope:"global" is only valid when every preceding block is also globally
+    // scoped (Anthropic prefix rule) — a trailing-only marker on a multi-page
+    // slab 400s the whole request, so the caller's global marker must cover
+    // EVERY page. Plain ephemeral keeps the cheaper trailing-only placement.
+    const markThisPage =
+      systemStaticCacheControl !== undefined
+      && (i === images.length - 1 || isGlobalScopeCacheControl(systemStaticCacheControl));
     imageBlocks.push(
-      i === images.length - 1 && systemStaticCacheControl !== undefined
+      markThisPage
         ? { ...imageBlock, cache_control: systemStaticCacheControl }
         : imageBlock,
     );

--- a/tests/anthropic-cache-align.test.ts
+++ b/tests/anthropic-cache-align.test.ts
@@ -98,6 +98,83 @@ describe('Anthropic cache contract — invariants that should already hold', () 
   });
 });
 
+describe('Anthropic cache contract — scope:"global" prefix consistency (upstream #95 shape)', () => {
+  // Anthropic rejects scope:"global" unless every preceding block is also
+  // globally scoped. A multi-image slab whose caller marker lands only on the
+  // LAST page is therefore an invalid prefix → every compressed request 400s.
+  // For the global-scope variant the caller's ONE marker must cover EVERY
+  // rendered page of the slab — a deliberate exception to "out count <= in
+  // count", which continues to hold for plain ephemeral markers (tests above).
+  const globalMark = { type: 'ephemeral', ttl: '1h', scope: 'global' };
+
+  function slabImagesOf(msgs: Message[]): any[] {
+    // slab pages = image blocks BEFORE the '[End of rendered context.]' boundary
+    for (const m of msgs) {
+      if (!Array.isArray(m.content)) continue;
+      const blocks = m.content as any[];
+      const end = blocks.findIndex((b) => b?.type === 'text' && b.text === '[End of rendered context.]');
+      if (end === -1) continue;
+      return blocks.slice(0, end).filter((b) => b?.type === 'image');
+    }
+    return [];
+  }
+
+  it('a scope:"global" caller marker lands on EVERY page of a multi-image slab', async () => {
+    const body = enc({
+      model: 'claude-3-5-sonnet',
+      system: [{ type: 'text', text: big(260_000), cache_control: globalMark }],
+      messages: [usr('hello, quick question')],
+    });
+    const { body: out, info } = await transformRequest(body);
+    expect(info.compressed).toBe(true);
+    const msgs = JSON.parse(new TextDecoder().decode(out)).messages as Message[];
+    const slabImgs = slabImagesOf(msgs);
+    expect(slabImgs.length).toBeGreaterThan(1); // must exercise the multi-page case
+    for (const img of slabImgs) {
+      expect(img.cache_control, 'every slab page must carry the global marker').toEqual(globalMark);
+    }
+  });
+
+  it('history-anchor relocation never opens a gap in a global-scoped prefix', async () => {
+    // With history collapse, the anchor extends onto the history image. Moving
+    // the slab marker there (the plain-ephemeral behaviour) would leave slab
+    // pages unmarked BEFORE a global block — the exact invalid shape. Global
+    // markers must be copied, never moved: slab pages keep theirs.
+    const body = enc({
+      model: 'claude-3-5-sonnet',
+      system: [{ type: 'text', text: big(260_000), cache_control: globalMark }],
+      messages: convo(15),
+    });
+    const { body: out, info } = await transformRequest(body);
+    expect(info.compressed).toBe(true);
+    const msgs = JSON.parse(new TextDecoder().decode(out)).messages as Message[];
+    const all = imagesOf(msgs);
+    const slabImgs = slabImagesOf(msgs);
+    expect(slabImgs.length).toBeGreaterThan(1);
+    for (const img of slabImgs) {
+      expect(img.cache_control, 'slab pages must keep the global marker after relocation').toEqual(globalMark);
+    }
+    // Prefix rule over image blocks: nothing unmarked may precede a global-marked block.
+    let gapped = false;
+    for (const img of all) {
+      if ((img.cache_control as any)?.scope === 'global') break;
+      gapped = true;
+      break;
+    }
+    expect(gapped, 'first image block must already be globally scoped').toBe(false);
+  });
+
+  it('plain ephemeral (no scope) keeps the existing single-marker behaviour', async () => {
+    const body = enc({
+      model: 'claude-3-5-sonnet',
+      system: [{ type: 'text', text: big(260_000), cache_control: { type: 'ephemeral' } }],
+      messages: [usr('hello, quick question')],
+    });
+    const { body: out } = await transformRequest(body);
+    expect(countCacheControlMarkers(out)).toBe(1);
+  });
+});
+
 describe('Anthropic cache contract — our agreed model (EXPECTED FAIL today)', () => {
   it('APPEND-ONLY: earlier history image stays byte-identical as the conversation grows past a chunk boundary', async () => {
     // Conversation P, then P + more turns that advance the collapse boundary.


### PR DESCRIPTION
## Root cause

Anthropic's `scope: "global"` cache rule requires **every preceding block to also be globally scoped**. The transform placed the caller's system-slab `cache_control` marker only on the **last** rendered page of a multi-image slab (`src/core/transform.ts`, slab splice), and the history-anchor relocation (`relocateAnchorToHistoryImage`) then **moved** that single marker off the slab entirely. Result: pages 1..N-1 sat unmarked before a globally-scoped block — an invalid prefix — so **any request whose slab renders to more than one page was rejected with `400 invalid_request_error`**.

Reproduced dynamically: a 260k-char system block with `cache_control: {type:"ephemeral", ttl:"1h", scope:"global"}` rendered to 10 pages with the marker only on `img[9]`.

## User-visible effect

Claude Code marks its system prompt with the global-scope marker, and any real session produces a multi-page slab — so compressed traffic 400'd on every request for those callers. After the fix the prefix is valid and requests go through, keeping the org-wide cache semantics the caller asked for.

## The fix (direction (a) — preserve global semantics)

- A `scope:"global"` caller marker now lands on **every** rendered slab page (plain ephemeral keeps the existing cheaper trailing-only placement — behavior unchanged).
- The history-anchor relocation **copies** a global marker onto the history image instead of moving it, so slab pages never lose theirs (no gap in the global prefix). Plain ephemeral keeps pure move semantics ("never adds" invariant untouched for that case).

## Tests

New `describe` in `tests/anthropic-cache-align.test.ts` (TDD — both failed before the fix, for the right reason):
- multi-image slab: global marker present on every page;
- history collapse: relocation opens no gap (slab pages keep the marker, first image block globally scoped);
- control: plain ephemeral still yields exactly one marker (existing invariants all still pass).

## Validation

- `tests/anthropic-cache-align.test.ts`: 12/12.
- Full suite, typecheck, build: green in the worktree.
- Lint: clean on the touched files. (Pre-existing: `eval/grok-density/run.mjs` has 4 lint errors on `main` — untouched here, flagged separately.)

## Notes / follow-up suggestions (not done here — out of scope)

- The tool_result / reminder image paths copy a source marker onto a *single* image; if one of those sources ever renders multi-image with a global marker, the same shape could reappear there.
- `CHANGELOG.md` on `main` currently has two `## [Unreleased]` headings (merge artifact) — worth unifying.
