### PR TITLE
chore: fix eval-harness lint errors and unify the duplicate Unreleased section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,6 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic ver
 
 ## [Unreleased]
 
-### Docs
-
-- **docs:** add a "Use with Claude clients" section to the README (and all 41
-  translations) covering Claude Code CLI on macOS/Linux, the **Windows
-  PowerShell** variant (`$env:ANTHROPIC_BASE_URL`), and **Claude Desktop** setup.
-  (thanks @ousamabenyounes)
-
-## [Unreleased]
-
 ### Added
 
 - **feat(grok):** opt-in support for xAI **Grok** on the OpenAI-compatible wire.
@@ -87,6 +78,13 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic ver
   image pixels — while the savings baseline credited only the stripped-schema
   delta. The imaged tool doc is now heading + schema only; the rendered-context
   framing no longer claims the image holds "full tool" docs. (thanks @rldyourmnd)
+
+### Docs
+
+- **docs:** add a "Use with Claude clients" section to the README (and all 41
+  translations) covering Claude Code CLI on macOS/Linux, the **Windows
+  PowerShell** variant (`$env:ANTHROPIC_BASE_URL`), and **Claude Desktop** setup.
+  (thanks @ousamabenyounes)
 
 ## [1.2.0] — 2026-07-08
 

--- a/eval/grok-density/run.mjs
+++ b/eval/grok-density/run.mjs
@@ -88,7 +88,7 @@ async function callModel(model, dataUrls, question) {
       signal: controller.signal,
     });
   } catch (err) {
-    throw new Error(`fetch failed: ${err && err.message ? err.message : err}`);
+    throw new Error(`fetch failed: ${err && err.message ? err.message : err}`, { cause: err });
   } finally {
     clearTimeout(timer);
   }
@@ -156,7 +156,7 @@ if (live) {
   const dataUrls = pages.map((p) => 'data:image/png;base64,' + Buffer.from(p.png).toString('base64'));
   const m = { exactCorrect: 0, exactTotal: 0, confab: 0, abstain: 0, refused: 0, gistOk: false, guardOk: false, answers: [] };
   for (const q of QUESTIONS) {
-    let text = '', ms = 0, status = null;
+    let text, ms, status;
     try {
       ({ text, ms, status } = await callModel(MODEL, dataUrls, q.q));
     } catch (err) {


### PR DESCRIPTION
Post-merge cleanup from the 2026-07-12 batch merge (PRs #12–#18). Two independent nits, no behavior change:

## Lint (`eval/grok-density/run.mjs` — 4 errors → 0)

- `preserve-caught-error`: the re-thrown fetch error now carries the original as `cause`.
- `no-useless-assignment` (×3): `let text = '', ms = 0, status = null` initializers were always overwritten by the destructuring assignment (and unused on the catch path) — now declared without initializers.

`pnpm run lint` is clean repo-wide again. The harness dry-run still runs identically (`$0`, `1 page(s) 764x1064 → 813 img tok vs 1168 text (30% saved)`); the generated `results.json` stays untracked.

## CHANGELOG

The merges left two `## [Unreleased]` headings. The Docs entry from the first block now lives in the single Unreleased section (after Fixed, matching the 1.2.0 section order). No entries added, removed, or reworded.

## Validation

lint ✓ · typecheck ✓ · full suite 962/962 ✓ · build ✓ · docs-integrity 5/5 ✓ · harness dry-run ✓