### PR TITLE
chore(release): 1.3.1 (docs-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,22 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic ver
 
 ## [Unreleased]
 
+## [1.3.1] — 2026-07-12
+
+Docs-only. Syncs the npm package page with the corrected 1.3.0 documentation
+(the 1.3.0 tarball was cut from the version-bump commit, before these edits).
+No change to the compression path, billing math, or any shipped behavior.
+
+### Docs
+
+- **docs:** the Grok changelog entry now describes the net shipped profile
+  (stock 5×8 white AA + in-image IDS), not the 9×12 cell that never shipped in
+  a tagged release; the universal IDS block, the 64 → 96 fact-sheet budget, and
+  the residual-height gate are split into their own `feat(render)` entry; the
+  two `$0` eval harnesses (`eval/grok-density`, `eval/ab/guards-3arm`) are
+  logged. The README gains an **Opt-in flags** note for `OMNIGLYPH_GUARD_SECRETS`,
+  `OMNIGLYPH_KEEP_SYSTEM_TEXT`, and the fail-closed Grok opt-in.
+
 ## [1.3.0] — 2026-07-12
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniglyph",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "Context-as-image compression proxy for LLMs: renders bulky context (system prompt, tool docs, history) as dense PNG pages with exact per-provider billing math (Anthropic/OpenAI/Gemini). Node and Cloudflare Workers. Part of the OmniRoute family.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Patch **docs-only** — sincroniza a página do pacote no npm com os docs corrigidos da 1.3.0.

O tarball da 1.3.0 foi construído a partir do commit de bump (antes dos ajustes de CHANGELOG/README), então a página do npm ficou com a versão pré-correção. **Zero mudança de código** (diff vs 1.3.0 = `CHANGELOG.md` + `README.md`).

- CHANGELOG: entrada do Grok descreve o perfil real shipado (5×8 branco + IDS), IDS-universal/factsheet-96/gate-residual em `feat(render)` próprio, harnesses de eval logados.
- README: subseção "Opt-in flags".

Smoke `--version` → 1.3.1.