### PR TITLE
docs(readme): FAQ — first-party client features can vanish behind any base-URL proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,9 @@ It proved the *channel* works — with an encoder/decoder pair trained for the j
 **Can I use it without Claude Code — Cursor, ChatGPT, a plain pipe?**
 Yes, two ways. As a **proxy** it works with any client that lets you set the API base URL (`ANTHROPIC_BASE_URL`, or the OpenAI base URL) — Claude Code, your own scripts, anything HTTP. And for tools that can't proxy, the **Offline export** above renders the context to PNG pages you paste in by hand — `omniglyph export --stdin` even reads straight from a Unix pipe.
 
+**A client feature (like Claude Code's `/remote-control`) disappears when I point it at the proxy — is that OmniGlyph?**
+No. A few client features gate themselves on a *first-party* connection — and on which auth source is set — inside the client itself, before any request ever reaches a proxy. So they can hide, or refuse to pair, behind *any* `ANTHROPIC_BASE_URL` proxy, not just OmniGlyph, and nothing the proxy returns can switch them back on. Run those features on a direct, no-proxy session.
+
 **How does it actually turn text into an image?**
 It reflows the text and paints it with a 1-bit 5×8 pixel glyph atlas onto dense 1568×728 PNG pages — one bit per pixel, no anti-aliasing, so the model bills the page by its dimensions, not by how many characters are inside. **How it works** above has the pipeline; the benchmarks doc has the geometry and why denser isn't always cheaper.
 


### PR DESCRIPTION
## Why

Users report that a client feature (e.g. Claude Code's `/remote-control`) disappears — or refuses to pair — once they point the client at OmniGlyph via `ANTHROPIC_BASE_URL`, and blame the proxy.

It isn't the proxy. A few client features gate their own visibility/eligibility on a **first-party** connection and on which auth source is set — a check that happens **inside the client, before any request reaches a proxy**. So they behave the same behind *any* base-URL proxy, and nothing the proxy returns can re-enable them.

## Change

One version-agnostic FAQ entry in `README.md`, next to the existing "Can I use it without Claude Code" proxy entry. No code, no links added.

`docs-integrity` + `lint` green. i18n replication (41 locales) available as a follow-up if wanted.