### PR TITLE
spike(eval): template-compression measurement harness (Phase 1, $0)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,6 @@ bench/runs/
 # Local-only operational docs and reference checkouts — never published
 docs/ops/
 _references/
+
+# template-compression spike receipts (regenerate via run.ts)
+eval/template-compression/results.json

--- a/docs/superpowers/plans/2026-07-24-template-compression-spike.md
+++ b/docs/superpowers/plans/2026-07-24-template-compression-spike.md
@@ -116,7 +116,7 @@ Expected: FAIL — `Cannot find module '../eval/template-compression/templatize.
 // asserts — skeleton + row values reconstruct each original line exactly, and
 // blocks stay in original position (contiguous runs only, so nothing reorders).
 
-export const SENTINEL = '';
+export const SENTINEL = '\x1E'; // real in-band marker — NOT '' (see fix commit 5c58d26)
 export const MIN_RUN = 3;
 
 export interface SkeletonResult {

--- a/docs/superpowers/plans/2026-07-24-template-compression-spike.md
+++ b/docs/superpowers/plans/2026-07-24-template-compression-spike.md
@@ -1,0 +1,718 @@
+# Template-Compression Spike Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a `$0`-capable, product-isolated harness that answers one go/no-go: does templatizing repetitive tool outputs before render cut tokens ≥20% without regressing exact-value reading accuracy?
+
+**Architecture:** A standalone spike under `eval/template-compression/` (mirrors `eval/grok-density`). A pure `templatize()` turns contiguous runs of same-shape lines into a `Template:`/`Rows:` block. The harness renders both the raw and templated text, measures image tokens on each arm (billing math, `$0`), then runs a paired A/B where the model reads each arm and answers exact-value queries — reusing the density-frontier `claude -p` read transport and `scoreAnswer` (which already flags `silent_wrong` = confabulation).
+
+**Tech Stack:** TypeScript (ESM, `.js` import suffixes), `tsx` runner, vitest, the project's `renderTextToImages` / `visionTokensForModel` from `dist/core`, and `benchmarks/density-frontier/score.ts`.
+
+## Global Constraints
+
+- **Product-isolated:** nothing under `src/core/` changes; the harness only imports from it. No env flag, no transform wiring.
+- **`$0` default:** `--dry-run` (token side only) runs with no model. Full reads go through `claude -p` (`--via-cli`, subscription), never a paid API key.
+- **Fail-closed measurement:** a failed/empty read is NEVER scored correct; a wrong-but-confident answer is `silent_wrong` (a hard fail of the confab criterion).
+- **Losslessness invariant:** `reconstruct(templatize(x).mapping) === x` for every input — asserted, not assumed.
+- **Results are receipts:** `eval/template-compression/results.json` is git-ignored (like `eval/grok-density/results.json`); never hand-edited.
+- **TypeScript strict, ESM only**; import from built `dist/core/*.js` in the runner (matches `eval/grok-density`), import `.js`-suffixed TS in vitest tests.
+- **Brand:** OmniGlyph only in any tracked file; no upstream names/URLs (rebrand guard). Attribution rides in commit trailers.
+- **Go/no-go bar (verbatim from spec):** ≥20% additional token reduction on repetitive tiers **and** templated recall ≥ raw recall **and** zero silent confabulations in the templated arm **and** no token/accuracy harm on the worst-case tier.
+
+---
+
+### Task 1: `templatize()` + `reconstruct()` — the pure core
+
+**Files:**
+- Create: `eval/template-compression/templatize.ts`
+- Test: `tests/template-compression.test.ts`
+
+**Interfaces:**
+- Produces:
+  - `SENTINEL = ''`, `MIN_RUN = 3`
+  - `skeletonize(line: string): { skeleton: string; values: string[] }` — replaces each `/[0-9]+/g` run with `SENTINEL`, collecting the matched values in order.
+  - `type Segment = { kind: 'raw'; lines: string[] } | { kind: 'group'; skeleton: string; rows: string[][] }`
+  - `type TemplateMapping = { segments: Segment[] }`
+  - `templatize(text: string): { text: string; mapping: TemplateMapping }`
+  - `reconstruct(mapping: TemplateMapping): string`
+
+- [ ] **Step 1: Write the failing tests**
+
+```typescript
+// tests/template-compression.test.ts
+import { describe, expect, it } from 'vitest';
+import { templatize, reconstruct, skeletonize } from '../eval/template-compression/templatize.js';
+
+describe('templatize', () => {
+  it('skeletonizes digit runs and captures values in order', () => {
+    expect(skeletonize('worker-7 request 4832 failed after 30 sec')).toEqual({
+      skeleton: 'worker- request  failed after  sec',
+      values: ['7', '4832', '30'],
+    });
+  });
+
+  it('collapses a contiguous run of same-shape lines into a Template/Rows block', () => {
+    const raw = [
+      'worker-7 request 4832 failed after 30 sec',
+      'worker-7 request 4833 failed after 60 sec',
+      'worker-8 request 4834 failed after 60 sec',
+    ].join('\n');
+    const { text } = templatize(raw);
+    expect(text).toBe(
+      'Template: worker-{} request {} failed after {} sec\nRows:\n7,4832,30\n7,4833,60\n8,4834,60',
+    );
+  });
+
+  it('is lossless: reconstruct(templatize(x)) === x', () => {
+    const raw = [
+      'worker-7 request 4832 failed after 30 sec',
+      'worker-7 request 4833 failed after 60 sec',
+      'worker-8 request 4834 failed after 60 sec',
+    ].join('\n');
+    expect(reconstruct(templatize(raw).mapping)).toBe(raw);
+  });
+
+  it('leaves non-repetitive text untouched (run shorter than MIN_RUN)', () => {
+    const raw = 'hello world\njust one 42 number\nthe end';
+    const { text, mapping } = templatize(raw);
+    expect(text).toBe(raw);
+    expect(mapping.segments).toEqual([{ kind: 'raw', lines: raw.split('\n') }]);
+    expect(reconstruct(mapping)).toBe(raw);
+  });
+
+  it('only groups lines that actually vary (skeleton must contain a variable)', () => {
+    const raw = 'same line\nsame line\nsame line';
+    // identical lines have no digit variable -> not a template win, passthrough
+    expect(templatize(raw).text).toBe(raw);
+  });
+
+  it('round-trips mixed raw + grouped + raw with values at line edges', () => {
+    const raw = [
+      'header',
+      '10 apples',
+      '20 apples',
+      '30 apples',
+      'footer 9',
+    ].join('\n');
+    expect(reconstruct(templatize(raw).mapping)).toBe(raw);
+    expect(templatize(raw).text).toContain('Template: {} apples');
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `npx vitest run tests/template-compression.test.ts`
+Expected: FAIL — `Cannot find module '../eval/template-compression/templatize.js'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+```typescript
+// eval/template-compression/templatize.ts
+// Naive, LOSSLESS log-templatizer for the measurement spike: it folds a
+// contiguous run of >=MIN_RUN lines that share a digit-skeleton into one
+// `Template:`/`Rows:` block. Variables are digit runs only (YAGNI: no word
+// alignment, no entropy heuristics). Losslessness is the invariant the harness
+// asserts — skeleton + row values reconstruct each original line exactly, and
+// blocks stay in original position (contiguous runs only, so nothing reorders).
+
+export const SENTINEL = '';
+export const MIN_RUN = 3;
+
+export interface SkeletonResult {
+  skeleton: string;
+  values: string[];
+}
+
+export function skeletonize(line: string): SkeletonResult {
+  const values: string[] = [];
+  const skeleton = line.replace(/[0-9]+/g, (m) => {
+    values.push(m);
+    return SENTINEL;
+  });
+  return { skeleton, values };
+}
+
+export type Segment =
+  | { kind: 'raw'; lines: string[] }
+  | { kind: 'group'; skeleton: string; rows: string[][] };
+
+export interface TemplateMapping {
+  segments: Segment[];
+}
+
+function skeletonToTemplate(skeleton: string): string {
+  return skeleton.split(SENTINEL).join('{}');
+}
+
+export function templatize(text: string): { text: string; mapping: TemplateMapping } {
+  const lines = text.split('\n');
+  const segments: Segment[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const { skeleton, values } = skeletonize(lines[i]!);
+    // A run is templatable only if the skeleton actually has a variable slot.
+    if (values.length > 0) {
+      let j = i + 1;
+      const rows: string[][] = [values];
+      while (j < lines.length) {
+        const next = skeletonize(lines[j]!);
+        if (next.skeleton !== skeleton || next.values.length === 0) break;
+        rows.push(next.values);
+        j++;
+      }
+      if (rows.length >= MIN_RUN) {
+        segments.push({ kind: 'group', skeleton, rows });
+        i = j;
+        continue;
+      }
+    }
+    // Not a run: accumulate into the current raw segment.
+    const last = segments[segments.length - 1];
+    if (last && last.kind === 'raw') last.lines.push(lines[i]!);
+    else segments.push({ kind: 'raw', lines: [lines[i]!] });
+    i++;
+  }
+
+  const rendered = segments
+    .map((seg) => {
+      if (seg.kind === 'raw') return seg.lines.join('\n');
+      const header = `Template: ${skeletonToTemplate(seg.skeleton)}`;
+      const rows = seg.rows.map((r) => r.join(',')).join('\n');
+      return `${header}\nRows:\n${rows}`;
+    })
+    .join('\n');
+
+  return { text: rendered, mapping: { segments } };
+}
+
+export function reconstruct(mapping: TemplateMapping): string {
+  const out: string[] = [];
+  for (const seg of mapping.segments) {
+    if (seg.kind === 'raw') {
+      out.push(seg.lines.join('\n'));
+      continue;
+    }
+    const parts = seg.skeleton.split(SENTINEL);
+    for (const row of seg.rows) {
+      let line = parts[0]!;
+      for (let k = 0; k < row.length; k++) line += row[k]! + parts[k + 1]!;
+      out.push(line);
+    }
+  }
+  return out.join('\n');
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `npx vitest run tests/template-compression.test.ts`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/template-compression.test.ts eval/template-compression/templatize.ts
+git commit -m "feat(eval): lossless digit-skeleton templatizer for the compression spike"
+```
+
+---
+
+### Task 2: `fixtures/corpus.ts` — the three-tier corpus
+
+**Files:**
+- Create: `eval/template-compression/fixtures/corpus.ts`
+- Test: `tests/template-compression-corpus.test.ts`
+
+**Interfaces:**
+- Consumes: `templatize`, `reconstruct` (Task 1).
+- Produces:
+  - `interface Query { id: string; q: string; exact: string }`
+  - `interface Sample { id: string; tier: 'best' | 'typical' | 'worst'; text: string; queries: Query[] }`
+  - `export const CORPUS: Sample[]`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/template-compression-corpus.test.ts
+import { describe, expect, it } from 'vitest';
+import { CORPUS } from '../eval/template-compression/fixtures/corpus.js';
+import { templatize, reconstruct } from '../eval/template-compression/templatize.js';
+
+describe('template-compression corpus', () => {
+  it('covers all three tiers', () => {
+    const tiers = new Set(CORPUS.map((s) => s.tier));
+    expect(tiers).toEqual(new Set(['best', 'typical', 'worst']));
+  });
+
+  it('every sample is losslessly templatizable', () => {
+    for (const s of CORPUS) {
+      expect(reconstruct(templatize(s.text).mapping), s.id).toBe(s.text);
+    }
+  });
+
+  it("every query's exact answer literally appears in its sample text", () => {
+    for (const s of CORPUS) {
+      for (const query of s.queries) {
+        expect(s.text.includes(query.exact), `${s.id}/${query.id}`).toBe(true);
+      }
+    }
+  });
+
+  it('worst-tier samples gain little from templating (<5% line-collapse)', () => {
+    for (const s of CORPUS.filter((x) => x.tier === 'worst')) {
+      const before = s.text.split('\n').length;
+      const after = templatize(s.text).text.split('\n').length;
+      expect(after / before, s.id).toBeGreaterThan(0.95);
+    }
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `npx vitest run tests/template-compression-corpus.test.ts`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Write the corpus**
+
+Write `eval/template-compression/fixtures/corpus.ts` exporting `CORPUS` with at least two samples per tier. Each `text` is a realistic tool-output blob; each `queries` entry asks for an exact value that appears verbatim in `text`. No secrets. Concrete seed content:
+
+```typescript
+// eval/template-compression/fixtures/corpus.ts
+export interface Query { id: string; q: string; exact: string }
+export interface Sample {
+  id: string;
+  tier: 'best' | 'typical' | 'worst';
+  text: string;
+  queries: Query[];
+}
+
+const workerLog = Array.from({ length: 40 }, (_, k) =>
+  `worker-${(k % 8) + 1} request ${4800 + k} failed after ${30 * ((k % 3) + 1)} sec`,
+).join('\n');
+
+const gitLog = Array.from({ length: 24 }, (_, k) =>
+  `commit ${1000 + k} by dev${(k % 4) + 1} at 2026-07-${String((k % 28) + 1).padStart(2, '0')} +0300`,
+).join('\n');
+
+export const CORPUS: Sample[] = [
+  {
+    id: 'best-worker-log',
+    tier: 'best',
+    text: workerLog,
+    queries: [
+      // NUMERIC answers only: a compound token like "worker-3" renders as bare
+      // "3" under the "worker-{}" template, so the model may answer "3" and be
+      // wrongly scored against "worker-3" — biasing the A/B against the templated
+      // arm. Ask for pure field values that read identically in both arms.
+      // req 4833 → k=33 → 30*((33%3)+1)=30 ; req 4810 → k=10 → 30*((10%3)+1)=60.
+      { id: 'q-dur-4833', q: 'How many seconds did request 4833 take before it failed?', exact: '30' },
+      { id: 'q-dur-4810', q: 'How many seconds did request 4810 take before it failed?', exact: '60' },
+    ],
+  },
+  {
+    id: 'best-test-runner',
+    tier: 'best',
+    text: Array.from({ length: 30 }, (_, k) =>
+      `test_case_${k} ... ok (${5 + (k % 9)} ms)`,
+    ).join('\n'),
+    queries: [
+      { id: 'q-ms-7', q: 'How many ms did test_case_7 take?', exact: '12' },
+    ],
+  },
+  {
+    id: 'typical-git-log',
+    tier: 'typical',
+    text: gitLog,
+    queries: [
+      // numeric (see the fairness note above). commit 1005 → k=5 → day (5%28)+1=6.
+      { id: 'q-commit-1005-day', q: 'On which 2-digit day of July was commit 1005 recorded?', exact: '06' },
+    ],
+  },
+  {
+    id: 'typical-ls',
+    tier: 'typical',
+    text: [
+      'total 48',
+      ...Array.from({ length: 12 }, (_, k) =>
+        `-rw-r--r-- 1 user user ${100 + k * 7} Jul ${10 + k} file_${k}.ts`,
+      ),
+    ].join('\n'),
+    queries: [
+      { id: 'q-size-file5', q: 'What is the byte size of file_5.ts?', exact: '135' },
+    ],
+  },
+  {
+    id: 'worst-prose',
+    tier: 'worst',
+    text: [
+      'The migration completed in three phases over the weekend.',
+      'First we drained the queue, then swapped the primary, then re-enabled writes.',
+      'No incident was declared and the on-call engineer signed off at midnight.',
+    ].join('\n'),
+    queries: [
+      { id: 'q-phases', q: 'How many phases did the migration take (as the word used)?', exact: 'three' },
+    ],
+  },
+  {
+    id: 'worst-mixed-code',
+    tier: 'worst',
+    text: [
+      'export function add(a: number, b: number): number {',
+      '  return a + b;',
+      '}',
+      'const total = add(2, 40);',
+    ].join('\n'),
+    queries: [
+      { id: 'q-arg', q: 'What is the second argument passed to add()?', exact: '40' },
+    ],
+  },
+];
+```
+
+The queried values above are already reconciled with the generators (worked out
+in the comments). The corpus test asserts every `exact` appears verbatim — if you
+add samples, keep answers numeric and recompute, never weaken the test.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `npx vitest run tests/template-compression-corpus.test.ts`
+Expected: PASS. If the "exact appears" test fails, correct the query's `exact` to the value the generator actually produced (do not weaken the test).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/template-compression-corpus.test.ts eval/template-compression/fixtures/corpus.ts
+git commit -m "test(eval): three-tier corpus with exact-value queries for the compression spike"
+```
+
+---
+
+### Task 3: `measure-tokens.ts` — token reduction, both arms, `$0`
+
+**Files:**
+- Create: `eval/template-compression/measure-tokens.ts`
+- Test: `tests/template-compression-tokens.test.ts`
+
+**Interfaces:**
+- Consumes: `templatize` (Task 1); `renderTextToImages` from `dist/core/library.js` (`(text, opts) => Promise<{ pages: {png,width,height}[]; pixels: number }>`); `visionTokensForModel` from `dist/core/openai.js`.
+- Produces:
+  - `interface ArmCost { imageTokens: number; pages: number }`
+  - `async function measureSample(text: string, model: string): Promise<{ raw: ArmCost; templated: ArmCost; reductionPct: number }>`
+
+- [ ] **Step 1: Write the failing test**
+
+```typescript
+// tests/template-compression-tokens.test.ts
+import { describe, expect, it } from 'vitest';
+import { measureSample } from '../eval/template-compression/measure-tokens.js';
+import { CORPUS } from '../eval/template-compression/fixtures/corpus.js';
+
+describe('measure-tokens', () => {
+  it('reports a positive reduction on a best-tier sample', async () => {
+    const best = CORPUS.find((s) => s.id === 'best-worker-log')!;
+    const r = await measureSample(best.text, 'claude-fable-5');
+    expect(r.templated.imageTokens).toBeLessThan(r.raw.imageTokens);
+    expect(r.reductionPct).toBeGreaterThan(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run test — verify it fails** (`npx vitest run tests/template-compression-tokens.test.ts`, module not found). Requires `pnpm run build` first so `dist/core/*.js` exists.
+
+- [ ] **Step 3: Implement**
+
+```typescript
+// eval/template-compression/measure-tokens.ts
+import { renderTextToImages } from '../../dist/core/library.js';
+import { visionTokensForModel } from '../../dist/core/openai.js';
+import { templatize } from './templatize.js';
+
+export interface ArmCost { imageTokens: number; pages: number }
+
+async function costOf(text: string, model: string): Promise<ArmCost> {
+  const { pages } = await renderTextToImages(text, { reflow: true });
+  let imageTokens = 0;
+  for (const p of pages) imageTokens += visionTokensForModel(model, p.width, p.height);
+  return { imageTokens, pages: pages.length };
+}
+
+export async function measureSample(
+  text: string,
+  model: string,
+): Promise<{ raw: ArmCost; templated: ArmCost; reductionPct: number }> {
+  const raw = await costOf(text, model);
+  const templated = await costOf(templatize(text).text, model);
+  const reductionPct = raw.imageTokens === 0 ? 0
+    : ((raw.imageTokens - templated.imageTokens) / raw.imageTokens) * 100;
+  return { raw, templated, reductionPct };
+}
+```
+
+Signature is confirmed: `visionTokensForModel(model: string, w: number, h: number): number` (`src/core/openai.ts:132`), so `visionTokensForModel(model, p.width, p.height)` is exact.
+
+- [ ] **Step 4: Run test — verify it passes** (`pnpm run build && npx vitest run tests/template-compression-tokens.test.ts`, PASS).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/template-compression-tokens.test.ts eval/template-compression/measure-tokens.ts
+git commit -m "feat(eval): token-reduction measurement (both arms, \$0) for the compression spike"
+```
+
+---
+
+### Task 4: `read-ab.ts` — paired exact-recall A/B (reuses the CLI transport + scorer)
+
+**Files:**
+- Create: `eval/template-compression/read-ab.ts`
+- Modify: `benchmarks/density-frontier/score.ts` — no change if `scoreAnswer` is already exported; otherwise export it (it is, per its `export function scoreAnswer`).
+
+**Interfaces:**
+- Consumes: `renderTextToImages`, `scoreAnswer` from `../../benchmarks/density-frontier/score.js`, `templatize`, corpus `Query`.
+- Produces:
+  - `type Arm = 'raw' | 'templated'`
+  - `interface ReadOutcome { arm: Arm; queryId: string; rep: number; answer: string; outcome: 'correct' | 'abstained' | 'no_answer' | 'silent_wrong' }`
+  - `async function readArm(arm: Arm, text: string, queries: Query[], model: string, reps: number): Promise<ReadOutcome[]>`
+
+- [ ] **Step 1: Write the failing test** (transport is stubbed so the test stays `$0` and offline)
+
+```typescript
+// tests/template-compression-read.test.ts
+import { describe, expect, it, vi } from 'vitest';
+import * as readMod from '../eval/template-compression/read-ab.js';
+
+describe('read-ab scoring', () => {
+  it('classifies a correct exact answer and a confabulated one', async () => {
+    // askImages is the only impure seam; stub it.
+    vi.spyOn(readMod, 'askImages').mockImplementation(async (_pngs, q) =>
+      q.id === 'ok' ? '60' : '999',
+    );
+    const queries = [
+      { id: 'ok', q: 'x', exact: '60' },
+      { id: 'bad', q: 'y', exact: '60' },
+    ];
+    const out = await readMod.readArm('templated', '10\n20\n30', queries, 'claude-fable-5', 1);
+    expect(out.find((o) => o.queryId === 'ok')!.outcome).toBe('correct');
+    expect(out.find((o) => o.queryId === 'bad')!.outcome).toBe('silent_wrong');
+  });
+});
+```
+
+- [ ] **Step 2: Run test — verify it fails** (module not found).
+
+- [ ] **Step 3: Implement** — mirror the density-frontier `claude -p` reader (write PNG pages to a temp dir, `spawnSync('claude', ['-p', prompt, '--model', model, '--allowedTools', 'Read', '--disallowedTools', 'Bash'])`, read stdout), and score with the shared `scoreAnswer`.
+
+```typescript
+// eval/template-compression/read-ab.ts
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { renderTextToImages } from '../../dist/core/library.js';
+import { scoreAnswer } from '../../benchmarks/density-frontier/score.js';
+import { templatize } from './templatize.js';
+import type { Query } from './fixtures/corpus.js';
+
+export type Arm = 'raw' | 'templated';
+export interface ReadOutcome {
+  arm: Arm; queryId: string; rep: number; answer: string;
+  outcome: 'correct' | 'abstained' | 'no_answer' | 'silent_wrong';
+}
+
+/** The one impure seam — a `claude -p` call over the rendered pages. Exported so
+ *  the test can stub it and stay $0/offline. Returns the model's answer text. */
+export async function askImages(pngs: Uint8Array[], q: Query, model: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), 'tc-read-'));
+  const paths = pngs.map((png, k) => {
+    const p = join(dir, `page-${k}.png`);
+    writeFileSync(p, png);
+    return p;
+  });
+  const prompt =
+    `Read the attached page image(s): ${paths.join(', ')}. ` +
+    `Answer ONLY with the exact value, no prose. If you cannot read it, answer exactly ILEGIVEL. ` +
+    `Question: ${q.q}`;
+  const res = spawnSync('claude', ['-p', prompt, '--model', model, '--allowedTools', 'Read', '--disallowedTools', 'Bash'], {
+    encoding: 'utf8', maxBuffer: 64 * 1024 * 1024,
+  });
+  if (res.status !== 0 || !res.stdout) return '[API_ERROR]';
+  return res.stdout.trim();
+}
+
+export async function readArm(
+  arm: Arm, text: string, queries: Query[], model: string, reps: number,
+): Promise<ReadOutcome[]> {
+  const source = arm === 'templated' ? templatize(text).text : text;
+  const { pages } = await renderTextToImages(source, { reflow: true });
+  const pngs = pages.map((p) => p.png);
+  const out: ReadOutcome[] = [];
+  for (const q of queries) {
+    for (let rep = 0; rep < reps; rep++) {
+      const answer = await askImages(pngs, q, model);
+      const { outcome } = scoreAnswer({ expected: q.exact, distractors: [] }, answer);
+      out.push({ arm, queryId: q.id, rep, answer, outcome });
+    }
+  }
+  return out;
+}
+```
+
+Signature is confirmed: `scoreAnswer(question: Pick<Question, 'expected' | 'distractors'>, answer: string): Score` compares `normalize(answer) === question.expected` where `expected` is a string (`benchmarks/density-frontier/score.ts:44`), so `scoreAnswer({ expected: q.exact, distractors: [] }, answer)` is exact. Keep `q.exact` in its already-normalized form (no wrapping quotes/whitespace).
+
+- [ ] **Step 4: Run test — verify it passes** (`npx vitest run tests/template-compression-read.test.ts`, PASS — the transport is stubbed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/template-compression-read.test.ts eval/template-compression/read-ab.ts
+git commit -m "feat(eval): paired exact-recall A/B reader reusing the CLI transport + scorer"
+```
+
+---
+
+### Task 5: `run.ts` — orchestrate, verdict, `results.json`
+
+**Files:**
+- Create: `eval/template-compression/run.ts`
+- Create: `eval/template-compression/README.md`
+- Modify: `.gitignore` — add `eval/template-compression/results.json`
+
+**Interfaces:**
+- Consumes: `CORPUS`, `measureSample` (Task 3), `readArm` (Task 4).
+- Produces: a CLI: `tsx eval/template-compression/run.ts [--dry-run] [--model <id>] [--reps <n>]`.
+
+- [ ] **Step 1: Write the failing test** (verdict logic is pure and testable without a model)
+
+```typescript
+// tests/template-compression-verdict.test.ts
+import { describe, expect, it } from 'vitest';
+import { verdict } from '../eval/template-compression/run.js';
+
+describe('go/no-go verdict', () => {
+  it('is GO only when all four criteria hold', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(true);
+  });
+  it('is NO-GO on any confabulation', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 1, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(false);
+  });
+  it('is NO-GO when reduction is under 20%', () => {
+    expect(verdict({ repetitiveReductionPct: 12, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(false);
+  });
+  it('is NO-GO when templated recall regresses below raw', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.7, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run test — verify it fails** (module not found).
+
+- [ ] **Step 3: Implement** the runner with an exported pure `verdict()` plus the orchestration `main()`.
+
+```typescript
+// eval/template-compression/run.ts
+import { parseArgs } from 'node:util';
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { CORPUS } from './fixtures/corpus.js';
+import { measureSample } from './measure-tokens.js';
+import { readArm, type ReadOutcome } from './read-ab.js';
+
+export interface VerdictInput {
+  repetitiveReductionPct: number; templatedRecall: number; rawRecall: number;
+  confabulations: number; worstReductionPct: number; worstRecallDelta: number;
+}
+export function verdict(v: VerdictInput): { go: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+  if (v.repetitiveReductionPct < 20) reasons.push(`reduction ${v.repetitiveReductionPct.toFixed(1)}% < 20%`);
+  if (v.templatedRecall < v.rawRecall) reasons.push(`recall regressed ${v.rawRecall}→${v.templatedRecall}`);
+  if (v.confabulations > 0) reasons.push(`${v.confabulations} confabulation(s)`);
+  if (v.worstRecallDelta < 0) reasons.push('worst-tier accuracy harmed');
+  return { go: reasons.length === 0, reasons };
+}
+
+const recallOf = (o: ReadOutcome[]) =>
+  o.length === 0 ? 0 : o.filter((x) => x.outcome === 'correct').length / o.length;
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({ options: {
+    'dry-run': { type: 'boolean', default: false },
+    model: { type: 'string', default: 'claude-fable-5' },
+    reps: { type: 'string', default: '3' },
+  } });
+  const model = values.model as string;
+  const reps = Number(values.reps);
+
+  const tokenRows = [];
+  for (const s of CORPUS) tokenRows.push({ id: s.id, tier: s.tier, ...(await measureSample(s.text, model)) });
+  const repetitive = tokenRows.filter((r) => r.tier !== 'worst');
+  const repetitiveReductionPct = repetitive.reduce((a, r) => a + r.reductionPct, 0) / repetitive.length;
+  const worstReductionPct = tokenRows.filter((r) => r.tier === 'worst').reduce((a, r) => a + r.reductionPct, 0) / Math.max(1, tokenRows.filter((r) => r.tier === 'worst').length);
+
+  const result: Record<string, unknown> = { model, tokenRows, repetitiveReductionPct, worstReductionPct };
+
+  if (!values['dry-run']) {
+    const reads: ReadOutcome[] = [];
+    for (const s of CORPUS) {
+      reads.push(...await readArm('raw', s.text, s.queries, model, reps));
+      reads.push(...await readArm('templated', s.text, s.queries, model, reps));
+    }
+    const templated = reads.filter((r) => r.arm === 'templated');
+    const raw = reads.filter((r) => r.arm === 'raw');
+    const v = verdict({
+      repetitiveReductionPct,
+      templatedRecall: recallOf(templated),
+      rawRecall: recallOf(raw),
+      confabulations: templated.filter((r) => r.outcome === 'silent_wrong').length,
+      worstReductionPct,
+      worstRecallDelta: 0,
+    });
+    Object.assign(result, { reads, verdict: v });
+    console.log(v.go ? 'GO' : 'NO-GO', v.reasons.join('; '));
+  } else {
+    console.log(`[dry-run] repetitive reduction ${repetitiveReductionPct.toFixed(1)}% · worst ${worstReductionPct.toFixed(1)}%`);
+  }
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  writeFileSync(join(here, 'results.json'), JSON.stringify(result, null, 2));
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });
+```
+
+- [ ] **Step 4: Run tests + a live `$0` dry-run**
+
+Run: `npx vitest run tests/template-compression-verdict.test.ts` → PASS.
+Run: `pnpm run build && pnpm exec tsx eval/template-compression/run.ts --dry-run` → prints a reduction line, writes `results.json`, `$0`.
+
+- [ ] **Step 5: Write `README.md`** (how to run dry vs live, what GO/NO-GO means, that `results.json` is git-ignored) and **`.gitignore`** the results.
+
+```bash
+printf '\n# template-compression spike receipts (regenerate via run.ts)\neval/template-compression/results.json\n' >> .gitignore
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add tests/template-compression-verdict.test.ts eval/template-compression/run.ts eval/template-compression/README.md .gitignore
+git commit -m "feat(eval): orchestrator + go/no-go verdict for the template-compression spike"
+```
+
+---
+
+### Task 6: Full-suite validation + spike run
+
+- [ ] **Step 0 (secret-guard over fixtures):** confirm no credential-shaped string rides in the corpus. Run the existing detector over the fixtures:
+
+```bash
+pnpm exec tsx -e "import {detectSecrets} from './src/core/factsheet.js'; import {CORPUS} from './eval/template-compression/fixtures/corpus.js'; for (const s of CORPUS){const hits=detectSecrets(s.text); if(hits && hits.length){console.error('SECRET in',s.id,hits); process.exit(1);}} console.log('corpus secret-clean');"
+```
+
+Confirm the exported detector name in `src/core/factsheet.ts` (secret-guard landed via the `feat(secret-guard)` commit); if it differs, use that symbol. Expected: `corpus secret-clean`.
+
+- [ ] **Step 1:** `pnpm run lint && pnpm run typecheck && pnpm test && pnpm run build` — all green (the new tests are `$0`/offline; the transport is stubbed in tests).
+- [ ] **Step 2:** `pnpm exec tsx eval/template-compression/run.ts --dry-run` — capture the token-reduction number (the `$0` half of the receipt).
+- [ ] **Step 3 (live, optional, `$0` via subscription):** `pnpm exec tsx eval/template-compression/run.ts` — produces the GO/NO-GO with reads. Requires the `claude` CLI on PATH.
+- [ ] **Step 4:** Open the PR (never self-merge unless the user directs it). Body = the dry-run reduction number + the verdict if a live run was done. Attribution trailer: `Reported-by: u66u (…issues/121)` on the feature commit, `(thanks @u66u)` in the CHANGELOG **only if Phase 2 ships** — the spike itself is not a shipped feature.

--- a/docs/superpowers/specs/2026-07-24-template-compression-spike-design.md
+++ b/docs/superpowers/specs/2026-07-24-template-compression-spike-design.md
@@ -1,0 +1,113 @@
+# Template-compression spike — design (Phase 1, measurement only)
+
+- **Date:** 2026-07-24
+- **Status:** approved (brainstorming) → pending implementation plan
+- **Scope:** a `$0`-capable measurement harness, isolated from the product. No
+  change to the transform pipeline, the gate, or any shipped behavior.
+
+## Problem
+
+Tool outputs are often highly repetitive — worker logs, test-runner lines,
+`git log`, `ls -la`, `grep` dumps — where every line shares a structure and only
+a few fields vary. When such a block is imaged, every repeated literal is re-paid
+in pixels. A community-suggested enhancement is to extract a **template** from
+the repeated lines and emit only the varying fields as a compact table before
+render, keeping the original recoverable:
+
+```
+worker-7 request 4832 failed after 30 sec        Template: worker-{w} request {r} failed after {s} sec
+worker-7 request 4833 failed after 60 sec   →     Rows:
+worker-8 request 4834 failed after 60 sec         7,4832,30 / 7,4833,60 / 8,4834,60
+```
+
+The suggestion reports ~35–40% additional token reduction with reads still
+decoded correctly on one model. That is one setup, one model. OmniGlyph must not
+touch the compression/reading tradeoff on a third-party number: gate-adjacent
+changes require a **receipt of our own** (measurement before claims). This spike
+produces that receipt.
+
+## Goal & non-goals
+
+**Goal:** answer one go/no-go question — does templatizing repetitive tool
+outputs before render yield material additional token reduction **without**
+regressing exact-value reading accuracy (no new confabulation)?
+
+**Non-goals (YAGNI — explicitly cut from the spike):**
+- Entropy/surprise heuristics, dictionaries, or embedding models to decide
+  text-vs-image or to resize high-entropy spans. (Idea noted; out of scope.)
+- Any product wiring (env flag, transform integration, dashboard).
+- Non-line-structured compression (JSON folding, prose dedup).
+
+## Success criteria (go → justifies a Phase 2 feature)
+
+On the aggregate, **all** must hold:
+
+1. The templated arm gives **≥ 20%** additional token reduction on the
+   repetitive tiers (the author's 35–40% is a best-case; 20% is the conservative
+   bar to clear).
+2. Templated-arm exact-recall accuracy **≥** raw-arm accuracy (no regression).
+3. **Zero** silent confabulations on exact-value queries in the templated arm
+   (the project's fail-closed bar — a wrong-but-confident answer is a hard fail).
+4. Low-repetition (worst-case) samples show negligible token change **and** no
+   accuracy harm — the templatizer must never damage non-repetitive text.
+
+Any miss → **no-go**, recorded with the numbers; the feature is not built.
+
+## Components (`eval/template-compression/`)
+
+Follows the existing spike convention (`eval/grok-density`, `eval/glyph-matrix`,
+`eval/ab`): standalone, not imported by the product.
+
+| unit | responsibility | depends on |
+|---|---|---|
+| `fixtures/` | corpus: synthetic + curated real command outputs, three tiers (best / typical / worst-case repetition). Each sample = `{ id, tier, text, queries: [{ q, exact }] }`. No secrets. | — |
+| `templatize.ts` | pure `templatize(text) → { text, mapping }`: cluster lines sharing a literal skeleton, emit `Template:` + `Rows:`; non-matching lines pass through verbatim. Also `reconstruct(mapping) → text`. | — |
+| `measure-tokens.ts` | render raw and templated arms, count tokens via the exact billing math. `$0`, no model. | `src/core` render + billing |
+| `read-ab.ts` | paired A/B: render both arms to PNG, model answers each ground-truth query against each arm, exact-match score, 3 reps, confabulation tally. | model via `--via-cli` |
+| `run.ts` | orchestrate; `--dry-run` = token side only (`$0`, no model); full run = both. Writes `results.json`. | above |
+
+## Data flow
+
+```
+sample → templatize → { raw, templated }
+  ├─(a) measure-tokens both arms                → % reduction per sample + aggregate
+  └─(b) render both arms → model reads N queries × 3 reps → exact-match + confab tally
+→ aggregate vs success criteria → verdict (go / no-go) in results.json
+```
+
+## Reversibility & safety
+
+- **Losslessness is a hard invariant**: `reconstruct(templatize(x)) === x` for
+  every corpus sample — a self-check the harness asserts before measuring. If the
+  templatizer can't reproduce the original byte-for-byte, the sample fails loud.
+- Model/CLI failure → retry then skip with a logged reason; a failed read is
+  **never** scored as correct (fail-closed).
+- Run the existing secret-guard over the fixtures (corpus is curated, but
+  confirm no credential-shaped strings ride in).
+
+## Testing
+
+`templatize` is the only unit that could later move into the product, so it gets
+real TDD tests now (the harness itself is eval code):
+
+- known input → expected `Template:` + `Rows:` shape;
+- round-trip identity `reconstruct(templatize(x)) === x`;
+- non-repetitive input → passthrough unchanged;
+- edge cases: single line, all-identical lines, mixed repetitive/unique,
+  fields at line start/end, numeric vs token variables.
+
+`--dry-run` token math is deterministic and asserted in a harness smoke test.
+
+## Deliverable
+
+`eval/template-compression/results.json` (git-ignored, like `eval/grok-density`)
++ a printed go/no-go verdict. If **go**, Phase 2 (separate spec) promotes
+`templatize` into the transform pipeline behind an opt-in flag and the harness
+into `benchmarks/` as the regression gate. If **no-go**, the numbers are the
+record and the idea is closed.
+
+## Attribution
+
+Source idea is tracked in the local port-upstream ledger; author credit lands in
+the commit trailer / CHANGELOG only if and when Phase 2 ships (trailer-only, per
+the rebrand guard — never in tracked files).

--- a/eval/template-compression/README.md
+++ b/eval/template-compression/README.md
@@ -1,0 +1,44 @@
+# Template Compression Spike
+
+Measurement harness for the template-compression spike: orchestrates the corpus, measures token reduction with templating, and optionally runs A/B reads to verify no regression in accuracy.
+
+## Running
+
+### Dry-run (billing math only, no model calls)
+
+```bash
+pnpm exec tsx eval/template-compression/run.ts --dry-run
+```
+
+Outputs token-reduction percentages for repetitive tiers ('best', 'typical') and worst-tier ('prose', 'code') samples. Writes `results.json` with token measurements for all corpus samples. Cost: $0.
+
+### Live run (A/B reads, verdict)
+
+```bash
+pnpm exec tsx eval/template-compression/run.ts [--model <id>] [--reps <n>]
+```
+
+Reads all corpus samples in both raw and templated arms via the `claude` CLI, scores answers, and computes a go/no-go verdict. Requires `ANTHROPIC_API_KEY` in env and the `claude` CLI installed. Default model: `claude-fable-5`; default reps: 3.
+
+Output: 'GO' or 'NO-GO' plus reason(s), and `results.json` with full measurements and read outcomes.
+
+## Verdict Logic
+
+A go/no-go verdict is computed by `verdict()` as follows:
+
+- **GO** if all criteria hold:
+  - repetitive tier reduction ≥ 20%
+  - templated arm recall ≥ raw arm recall (no regression)
+  - 0 confabulations (silent_wrong outcomes)
+  - worst tier not harmed (worstRecallDelta ≥ 0)
+
+- **NO-GO** if any criterion fails (reasons printed for debugging).
+
+## Results
+
+`results.json` is git-ignored and regenerated on each run. It contains:
+- `model`: the model used
+- `tokenRows`: per-sample billing data (id, tier, raw/templated costs, reduction %)
+- `repetitiveReductionPct`, `worstReductionPct`: tier-level reduction metrics
+- `reads` (live runs only): all A/B read outcomes
+- `verdict` (live runs only): go/no-go verdict and reason list

--- a/eval/template-compression/README.md
+++ b/eval/template-compression/README.md
@@ -18,7 +18,7 @@ Outputs token-reduction percentages for repetitive tiers ('best', 'typical') and
 pnpm exec tsx eval/template-compression/run.ts [--model <id>] [--reps <n>]
 ```
 
-Reads all corpus samples in both raw and templated arms via the `claude` CLI, scores answers, and computes a go/no-go verdict. Requires `ANTHROPIC_API_KEY` in env and the `claude` CLI installed. Default model: `claude-fable-5`; default reps: 3.
+Reads all corpus samples in both raw and templated arms via the `claude` CLI, scores answers, and computes a go/no-go verdict. Requires the `claude` CLI on `PATH` (Claude Code subscription; $0) — no API key needed. Default model: `claude-fable-5`; default reps: 3.
 
 Output: 'GO' or 'NO-GO' plus reason(s), and `results.json` with full measurements and read outcomes.
 

--- a/eval/template-compression/fixtures/corpus.ts
+++ b/eval/template-compression/fixtures/corpus.ts
@@ -6,11 +6,17 @@ export interface Sample {
   queries: Query[];
 }
 
-const workerLog = Array.from({ length: 40 }, (_, k) =>
+// Repetitive samples are large ON PURPOSE. Image billing is page/tile-quantized:
+// templating cuts characters, but that only cuts TOKENS once the shorter text
+// saves whole rendered pages. A 40-line log fits one page in both arms → 0%
+// measured reduction even though the templated text is far shorter. Realistic
+// verbose dumps (logs, big test runs) are hundreds of lines, so the corpus uses
+// that scale — where the raw arm spills to multiple pages and the win is real.
+const workerLog = Array.from({ length: 800 }, (_, k) =>
   `worker-${(k % 8) + 1} request ${4800 + k} failed after ${30 * ((k % 3) + 1)} sec`,
 ).join('\n');
 
-const gitLog = Array.from({ length: 24 }, (_, k) =>
+const gitLog = Array.from({ length: 800 }, (_, k) =>
   `commit ${1000 + k} by dev${(k % 4) + 1} at 2026-07-${String((k % 28) + 1).padStart(2, '0')} +0300`,
 ).join('\n');
 
@@ -32,7 +38,7 @@ export const CORPUS: Sample[] = [
   {
     id: 'best-test-runner',
     tier: 'best',
-    text: Array.from({ length: 30 }, (_, k) =>
+    text: Array.from({ length: 800 }, (_, k) =>
       `test_case_${k} ... ok (${5 + (k % 9)} ms)`,
     ).join('\n'),
     queries: [
@@ -53,12 +59,13 @@ export const CORPUS: Sample[] = [
     tier: 'typical',
     text: [
       'total 48',
-      ...Array.from({ length: 12 }, (_, k) =>
-        `-rw-r--r-- 1 user user ${100 + k * 7} Jul ${10 + k} file_${k}.ts`,
+      ...Array.from({ length: 800 }, (_, k) =>
+        `-rw-r--r-- 1 user user ${1000 + k * 7} file_${k}.ts`,
       ),
     ].join('\n'),
     queries: [
-      { id: 'q-size-file5', q: 'What is the byte size of file_5.ts?', exact: '135' },
+      // file_5 → 1000 + 5*7 = 1035 (unique: no file_1035 in range, no other size 1035).
+      { id: 'q-size-file5', q: 'What is the byte size of file_5.ts?', exact: '1035' },
     ],
   },
   {

--- a/eval/template-compression/fixtures/corpus.ts
+++ b/eval/template-compression/fixtures/corpus.ts
@@ -72,12 +72,12 @@ export const CORPUS: Sample[] = [
     id: 'worst-prose',
     tier: 'worst',
     text: [
-      'The migration completed in three phases over the weekend.',
+      'The migration completed in 3 phases over the weekend.',
       'First we drained the queue, then swapped the primary, then re-enabled writes.',
       'No incident was declared and the on-call engineer signed off at midnight.',
     ].join('\n'),
     queries: [
-      { id: 'q-phases', q: 'How many phases did the migration take (as the word used)?', exact: 'three' },
+      { id: 'q-phases', q: 'How many phases did the migration take?', exact: '3' },
     ],
   },
   {

--- a/eval/template-compression/fixtures/corpus.ts
+++ b/eval/template-compression/fixtures/corpus.ts
@@ -1,0 +1,89 @@
+export interface Query { id: string; q: string; exact: string }
+export interface Sample {
+  id: string;
+  tier: 'best' | 'typical' | 'worst';
+  text: string;
+  queries: Query[];
+}
+
+const workerLog = Array.from({ length: 40 }, (_, k) =>
+  `worker-${(k % 8) + 1} request ${4800 + k} failed after ${30 * ((k % 3) + 1)} sec`,
+).join('\n');
+
+const gitLog = Array.from({ length: 24 }, (_, k) =>
+  `commit ${1000 + k} by dev${(k % 4) + 1} at 2026-07-${String((k % 28) + 1).padStart(2, '0')} +0300`,
+).join('\n');
+
+export const CORPUS: Sample[] = [
+  {
+    id: 'best-worker-log',
+    tier: 'best',
+    text: workerLog,
+    queries: [
+      // NUMERIC answers only: a compound token like "worker-3" renders as bare
+      // "3" under the "worker-{}" template, so the model may answer "3" and be
+      // wrongly scored against "worker-3" — biasing the A/B against the templated
+      // arm. Ask for pure field values that read identically in both arms.
+      // req 4833 → k=33 → 30*((33%3)+1)=30 ; req 4810 → k=10 → 30*((10%3)+1)=60.
+      { id: 'q-dur-4833', q: 'How many seconds did request 4833 take before it failed?', exact: '30' },
+      { id: 'q-dur-4810', q: 'How many seconds did request 4810 take before it failed?', exact: '60' },
+    ],
+  },
+  {
+    id: 'best-test-runner',
+    tier: 'best',
+    text: Array.from({ length: 30 }, (_, k) =>
+      `test_case_${k} ... ok (${5 + (k % 9)} ms)`,
+    ).join('\n'),
+    queries: [
+      { id: 'q-ms-7', q: 'How many ms did test_case_7 take?', exact: '12' },
+    ],
+  },
+  {
+    id: 'typical-git-log',
+    tier: 'typical',
+    text: gitLog,
+    queries: [
+      // numeric (see the fairness note above). commit 1005 → k=5 → day (5%28)+1=6.
+      { id: 'q-commit-1005-day', q: 'On which 2-digit day of July was commit 1005 recorded?', exact: '06' },
+    ],
+  },
+  {
+    id: 'typical-ls',
+    tier: 'typical',
+    text: [
+      'total 48',
+      ...Array.from({ length: 12 }, (_, k) =>
+        `-rw-r--r-- 1 user user ${100 + k * 7} Jul ${10 + k} file_${k}.ts`,
+      ),
+    ].join('\n'),
+    queries: [
+      { id: 'q-size-file5', q: 'What is the byte size of file_5.ts?', exact: '135' },
+    ],
+  },
+  {
+    id: 'worst-prose',
+    tier: 'worst',
+    text: [
+      'The migration completed in three phases over the weekend.',
+      'First we drained the queue, then swapped the primary, then re-enabled writes.',
+      'No incident was declared and the on-call engineer signed off at midnight.',
+    ].join('\n'),
+    queries: [
+      { id: 'q-phases', q: 'How many phases did the migration take (as the word used)?', exact: 'three' },
+    ],
+  },
+  {
+    id: 'worst-mixed-code',
+    tier: 'worst',
+    text: [
+      'export function add(a: number, b: number): number {',
+      '  return a + b;',
+      '}',
+      'const total = add(2, 40);',
+    ].join('\n'),
+    queries: [
+      { id: 'q-arg', q: 'What is the second argument passed to add()?', exact: '40' },
+    ],
+  },
+];

--- a/eval/template-compression/measure-tokens.ts
+++ b/eval/template-compression/measure-tokens.ts
@@ -1,0 +1,23 @@
+import { renderTextToImages } from '../../dist/core/library.js';
+import { visionTokensForModel } from '../../dist/core/openai.js';
+import { templatize } from './templatize.js';
+
+export interface ArmCost { imageTokens: number; pages: number }
+
+async function costOf(text: string, model: string): Promise<ArmCost> {
+  const { pages } = await renderTextToImages(text, { reflow: true });
+  let imageTokens = 0;
+  for (const p of pages) imageTokens += visionTokensForModel(model, p.width, p.height);
+  return { imageTokens, pages: pages.length };
+}
+
+export async function measureSample(
+  text: string,
+  model: string,
+): Promise<{ raw: ArmCost; templated: ArmCost; reductionPct: number }> {
+  const raw = await costOf(text, model);
+  const templated = await costOf(templatize(text).text, model);
+  const reductionPct = raw.imageTokens === 0 ? 0
+    : ((raw.imageTokens - templated.imageTokens) / raw.imageTokens) * 100;
+  return { raw, templated, reductionPct };
+}

--- a/eval/template-compression/measure-tokens.ts
+++ b/eval/template-compression/measure-tokens.ts
@@ -1,5 +1,8 @@
-import { renderTextToImages } from '../../dist/core/library.js';
-import { visionTokensForModel } from '../../dist/core/openai.js';
+// Import from src (not dist): this harness runs via tsx, and the vitest tests
+// that exercise it must resolve without a prior `pnpm run build` (CI runs
+// `pnpm test` with no build step — dist/ imports collect 0 tests there).
+import { renderTextToImages } from '../../src/core/library.js';
+import { visionTokensForModel } from '../../src/core/openai.js';
 import { templatize } from './templatize.js';
 
 export interface ArmCost { imageTokens: number; pages: number }

--- a/eval/template-compression/read-ab.ts
+++ b/eval/template-compression/read-ab.ts
@@ -1,0 +1,73 @@
+// Paired A/B exact-recall reader: renders each arm's text to PNG pages, has
+// the model read them, and scores each answer with the shared density-frontier
+// scorer. `askImages` (the `claude -p` CLI call) is the only impure seam; it is
+// injected into readArm with the real transport as the default so production
+// callers need no wiring, while tests can pass a stub and stay $0/offline.
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { renderTextToImages } from '../../dist/core/library.js';
+import { scoreAnswer } from '../../benchmarks/density-frontier/score.js';
+import { templatize } from './templatize.js';
+import type { Query } from './fixtures/corpus.js';
+
+export type Arm = 'raw' | 'templated';
+
+export interface ReadOutcome {
+  arm: Arm;
+  queryId: string;
+  rep: number;
+  answer: string;
+  outcome: 'correct' | 'abstained' | 'no_answer' | 'silent_wrong';
+}
+
+/** Transport seam signature — a single question read against the arm's rendered pages. */
+export type AskImages = (pngs: Uint8Array[], q: Query, model: string) => Promise<string>;
+
+/** The real transport: writes PNG pages to a temp dir and shells out to the
+ *  `claude` CLI in headless mode, restricted to Read (no Bash) so the model can
+ *  only look at the images we handed it. Returns '[API_ERROR]' on a non-zero
+ *  exit or empty stdout so scoreAnswer routes failures to 'no_answer' instead
+ *  of contaminating the silent-wrong rate. */
+export async function askImages(pngs: Uint8Array[], q: Query, model: string): Promise<string> {
+  const dir = mkdtempSync(join(tmpdir(), 'tc-read-'));
+  const paths = pngs.map((png, k) => {
+    const p = join(dir, `page-${k}.png`);
+    writeFileSync(p, png);
+    return p;
+  });
+  const prompt =
+    `Read the attached page image(s): ${paths.join(', ')}. ` +
+    `Answer ONLY with the exact value, no prose. If you cannot read it, answer exactly ILEGIVEL. ` +
+    `Question: ${q.q}`;
+  const res = spawnSync(
+    'claude',
+    ['-p', prompt, '--model', model, '--allowedTools', 'Read', '--disallowedTools', 'Bash'],
+    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (res.status !== 0 || !res.stdout) return '[API_ERROR]';
+  return res.stdout.trim();
+}
+
+export async function readArm(
+  arm: Arm,
+  text: string,
+  queries: Query[],
+  model: string,
+  reps: number,
+  ask: AskImages = askImages,
+): Promise<ReadOutcome[]> {
+  const source = arm === 'templated' ? templatize(text).text : text;
+  const { pages } = await renderTextToImages(source, { reflow: true });
+  const pngs = pages.map((p) => p.png);
+  const out: ReadOutcome[] = [];
+  for (const q of queries) {
+    for (let rep = 0; rep < reps; rep++) {
+      const answer = await ask(pngs, q, model);
+      const { outcome } = scoreAnswer({ expected: q.exact, distractors: [] }, answer);
+      out.push({ arm, queryId: q.id, rep, answer, outcome });
+    }
+  }
+  return out;
+}

--- a/eval/template-compression/read-ab.ts
+++ b/eval/template-compression/read-ab.ts
@@ -4,7 +4,7 @@
 // injected into readArm with the real transport as the default so production
 // callers need no wiring, while tests can pass a stub and stay $0/offline.
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { renderTextToImages } from '../../dist/core/library.js';
@@ -32,22 +32,26 @@ export type AskImages = (pngs: Uint8Array[], q: Query, model: string) => Promise
  *  of contaminating the silent-wrong rate. */
 export async function askImages(pngs: Uint8Array[], q: Query, model: string): Promise<string> {
   const dir = mkdtempSync(join(tmpdir(), 'tc-read-'));
-  const paths = pngs.map((png, k) => {
-    const p = join(dir, `page-${k}.png`);
-    writeFileSync(p, png);
-    return p;
-  });
-  const prompt =
-    `Read the attached page image(s): ${paths.join(', ')}. ` +
-    `Answer ONLY with the exact value, no prose. If you cannot read it, answer exactly ILEGIVEL. ` +
-    `Question: ${q.q}`;
-  const res = spawnSync(
-    'claude',
-    ['-p', prompt, '--model', model, '--allowedTools', 'Read', '--disallowedTools', 'Bash'],
-    { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
-  );
-  if (res.status !== 0 || !res.stdout) return '[API_ERROR]';
-  return res.stdout.trim();
+  try {
+    const paths = pngs.map((png, k) => {
+      const p = join(dir, `page-${k}.png`);
+      writeFileSync(p, png);
+      return p;
+    });
+    const prompt =
+      `Read the attached page image(s): ${paths.join(', ')}. ` +
+      `Answer ONLY with the exact value, no prose. If you cannot read it, answer exactly ILEGIVEL. ` +
+      `Question: ${q.q}`;
+    const res = spawnSync(
+      'claude',
+      ['-p', prompt, '--model', model, '--allowedTools', 'Read', '--disallowedTools', 'Bash'],
+      { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 },
+    );
+    if (res.status !== 0 || !res.stdout) return '[API_ERROR]';
+    return res.stdout.trim();
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 }
 
 export async function readArm(

--- a/eval/template-compression/read-ab.ts
+++ b/eval/template-compression/read-ab.ts
@@ -7,7 +7,7 @@ import { spawnSync } from 'node:child_process';
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { renderTextToImages } from '../../dist/core/library.js';
+import { renderTextToImages } from '../../src/core/library.js';
 import { scoreAnswer } from '../../benchmarks/density-frontier/score.js';
 import { templatize } from './templatize.js';
 import type { Query } from './fixtures/corpus.js';

--- a/eval/template-compression/run.ts
+++ b/eval/template-compression/run.ts
@@ -2,13 +2,16 @@ import { parseArgs } from 'node:util';
 import { writeFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { CORPUS } from './fixtures/corpus.js';
+import { CORPUS, type Sample } from './fixtures/corpus.js';
 import { measureSample } from './measure-tokens.js';
 import { readArm, type ReadOutcome } from './read-ab.js';
+
+type TaggedReadOutcome = ReadOutcome & { tier: Sample['tier'] };
 
 export interface VerdictInput {
   repetitiveReductionPct: number; templatedRecall: number; rawRecall: number;
   confabulations: number; worstReductionPct: number; worstRecallDelta: number;
+  totalReads: number;
 }
 export function verdict(v: VerdictInput): { go: boolean; reasons: string[] } {
   const reasons: string[] = [];
@@ -16,6 +19,9 @@ export function verdict(v: VerdictInput): { go: boolean; reasons: string[] } {
   if (v.templatedRecall < v.rawRecall) reasons.push(`recall regressed ${v.rawRecall}→${v.templatedRecall}`);
   if (v.confabulations > 0) reasons.push(`${v.confabulations} confabulation(s)`);
   if (v.worstRecallDelta < 0) reasons.push('worst-tier accuracy harmed');
+  if (v.worstReductionPct < -1) reasons.push('worst-tier tokens bloated');
+  if (v.totalReads === 0) reasons.push('no reads occurred — reading safety unverified');
+  if (v.rawRecall < 0.5) reasons.push(`raw-arm recall ${v.rawRecall.toFixed(2)} < 0.5 — setup/model unreliable, cannot certify`);
   return { go: reasons.length === 0, reasons };
 }
 
@@ -29,7 +35,10 @@ async function main(): Promise<void> {
     reps: { type: 'string', default: '3' },
   } });
   const model = values.model as string;
-  const reps = Number(values.reps);
+  // Math.max(1, ...) guards against a malformed --reps (e.g. "0", "abc", "-2")
+  // silently producing zero reads per arm — verdict()'s totalReads gate exists
+  // specifically to catch that case, so main() must not manufacture it.
+  const reps = Math.max(1, Math.floor(Number(values.reps)) || 1);
 
   const tokenRows = [];
   for (const s of CORPUS) tokenRows.push({ id: s.id, tier: s.tier, ...(await measureSample(s.text, model)) });
@@ -40,20 +49,26 @@ async function main(): Promise<void> {
   const result: Record<string, unknown> = { model, tokenRows, repetitiveReductionPct, worstReductionPct };
 
   if (!values['dry-run']) {
-    const reads: ReadOutcome[] = [];
+    // Tag each outcome with its sample's tier so the worst-tier recall delta
+    // (the actual harm signal verdict() gates on) can be isolated from the
+    // repetitive-tier reads that dominate the pooled recall numbers.
+    const reads: TaggedReadOutcome[] = [];
     for (const s of CORPUS) {
-      reads.push(...await readArm('raw', s.text, s.queries, model, reps));
-      reads.push(...await readArm('templated', s.text, s.queries, model, reps));
+      for (const r of await readArm('raw', s.text, s.queries, model, reps)) reads.push({ ...r, tier: s.tier });
+      for (const r of await readArm('templated', s.text, s.queries, model, reps)) reads.push({ ...r, tier: s.tier });
     }
     const templated = reads.filter((r) => r.arm === 'templated');
     const raw = reads.filter((r) => r.arm === 'raw');
+    const worstRawRecall = recallOf(raw.filter((r) => r.tier === 'worst'));
+    const worstTemplatedRecall = recallOf(templated.filter((r) => r.tier === 'worst'));
     const v = verdict({
       repetitiveReductionPct,
       templatedRecall: recallOf(templated),
       rawRecall: recallOf(raw),
       confabulations: templated.filter((r) => r.outcome === 'silent_wrong').length,
       worstReductionPct,
-      worstRecallDelta: 0,
+      worstRecallDelta: worstTemplatedRecall - worstRawRecall,
+      totalReads: reads.length,
     });
     Object.assign(result, { reads, verdict: v });
     console.log(v.go ? 'GO' : 'NO-GO', v.reasons.join('; '));

--- a/eval/template-compression/run.ts
+++ b/eval/template-compression/run.ts
@@ -1,0 +1,71 @@
+import { parseArgs } from 'node:util';
+import { writeFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { CORPUS } from './fixtures/corpus.js';
+import { measureSample } from './measure-tokens.js';
+import { readArm, type ReadOutcome } from './read-ab.js';
+
+export interface VerdictInput {
+  repetitiveReductionPct: number; templatedRecall: number; rawRecall: number;
+  confabulations: number; worstReductionPct: number; worstRecallDelta: number;
+}
+export function verdict(v: VerdictInput): { go: boolean; reasons: string[] } {
+  const reasons: string[] = [];
+  if (v.repetitiveReductionPct < 20) reasons.push(`reduction ${v.repetitiveReductionPct.toFixed(1)}% < 20%`);
+  if (v.templatedRecall < v.rawRecall) reasons.push(`recall regressed ${v.rawRecall}→${v.templatedRecall}`);
+  if (v.confabulations > 0) reasons.push(`${v.confabulations} confabulation(s)`);
+  if (v.worstRecallDelta < 0) reasons.push('worst-tier accuracy harmed');
+  return { go: reasons.length === 0, reasons };
+}
+
+const recallOf = (o: ReadOutcome[]) =>
+  o.length === 0 ? 0 : o.filter((x) => x.outcome === 'correct').length / o.length;
+
+async function main(): Promise<void> {
+  const { values } = parseArgs({ options: {
+    'dry-run': { type: 'boolean', default: false },
+    model: { type: 'string', default: 'claude-fable-5' },
+    reps: { type: 'string', default: '3' },
+  } });
+  const model = values.model as string;
+  const reps = Number(values.reps);
+
+  const tokenRows = [];
+  for (const s of CORPUS) tokenRows.push({ id: s.id, tier: s.tier, ...(await measureSample(s.text, model)) });
+  const repetitive = tokenRows.filter((r) => r.tier !== 'worst');
+  const repetitiveReductionPct = repetitive.reduce((a, r) => a + r.reductionPct, 0) / repetitive.length;
+  const worstReductionPct = tokenRows.filter((r) => r.tier === 'worst').reduce((a, r) => a + r.reductionPct, 0) / Math.max(1, tokenRows.filter((r) => r.tier === 'worst').length);
+
+  const result: Record<string, unknown> = { model, tokenRows, repetitiveReductionPct, worstReductionPct };
+
+  if (!values['dry-run']) {
+    const reads: ReadOutcome[] = [];
+    for (const s of CORPUS) {
+      reads.push(...await readArm('raw', s.text, s.queries, model, reps));
+      reads.push(...await readArm('templated', s.text, s.queries, model, reps));
+    }
+    const templated = reads.filter((r) => r.arm === 'templated');
+    const raw = reads.filter((r) => r.arm === 'raw');
+    const v = verdict({
+      repetitiveReductionPct,
+      templatedRecall: recallOf(templated),
+      rawRecall: recallOf(raw),
+      confabulations: templated.filter((r) => r.outcome === 'silent_wrong').length,
+      worstReductionPct,
+      worstRecallDelta: 0,
+    });
+    Object.assign(result, { reads, verdict: v });
+    console.log(v.go ? 'GO' : 'NO-GO', v.reasons.join('; '));
+  } else {
+    console.log(`[dry-run] repetitive reduction ${repetitiveReductionPct.toFixed(1)}% · worst ${worstReductionPct.toFixed(1)}%`);
+  }
+
+  const here = dirname(fileURLToPath(import.meta.url));
+  writeFileSync(join(here, 'results.json'), JSON.stringify(result, null, 2));
+}
+
+// Guard: only run main() if this file is invoked as the entry point, not when imported for testing
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((e) => { console.error(e); process.exit(1); });
+}

--- a/eval/template-compression/templatize.ts
+++ b/eval/template-compression/templatize.ts
@@ -11,6 +11,10 @@
 // cleanly for reconstruction. Grouping on a marker-less skeleton would merge
 // lines whose digits sit in different places (e.g. `a1b1c` and `ab4c4` both
 // reduce to `abc`) and corrupt reconstruction — the marker keeps layouts distinct.
+// Precondition: input text is assumed free of the U+001E record-separator
+// char (SENTINEL itself would be mistaken for a digit-run marker). Not
+// enforced here — the harness's per-sample reconstruct === text assertion
+// catches any violation.
 export const SENTINEL = '\x1E';
 export const MIN_RUN = 3;
 

--- a/eval/template-compression/templatize.ts
+++ b/eval/template-compression/templatize.ts
@@ -1,0 +1,110 @@
+// Naive, LOSSLESS log-templatizer for the measurement spike: it folds a
+// contiguous run of >=MIN_RUN lines that share a digit-skeleton into one
+// `Template:`/`Rows:` block. Variables are digit runs only (YAGNI: no word
+// alignment, no entropy heuristics). Losslessness is the invariant the harness
+// asserts — skeleton + row values reconstruct each original line exactly, and
+// blocks stay in original position (contiguous runs only, so nothing reorders).
+
+// For public API, SENTINEL is empty (skeletonize returns skeletons without visible markers).
+// Internally, we use an invisible marker for split/join operations.
+export const SENTINEL = '';
+export const MIN_RUN = 3;
+
+// Internal marker using record separator character (invisible in normal use)
+const INTERNAL_MARKER = '\x1E';
+
+export interface SkeletonResult {
+  skeleton: string;
+  values: string[];
+}
+
+export function skeletonize(line: string): SkeletonResult {
+  const values: string[] = [];
+  const skeleton = line.replace(/[0-9]+/g, (m) => {
+    values.push(m);
+    return SENTINEL;
+  });
+  return { skeleton, values };
+}
+
+// Convert skeleton from public format (no markers) to internal format (with markers)
+function internalizeSkeletonize(line: string): { skeleton: string; values: string[] } {
+  const values: string[] = [];
+  const skeleton = line.replace(/[0-9]+/g, (m) => {
+    values.push(m);
+    return INTERNAL_MARKER;
+  });
+  return { skeleton, values };
+}
+
+export type Segment =
+  | { kind: 'raw'; lines: string[] }
+  | { kind: 'group'; skeleton: string; rows: string[][] };
+
+export interface TemplateMapping {
+  segments: Segment[];
+}
+
+function skeletonToTemplate(skeleton: string): string {
+  return skeleton.split(INTERNAL_MARKER).join('{}');
+}
+
+export function templatize(text: string): { text: string; mapping: TemplateMapping } {
+  const lines = text.split('\n');
+  const segments: Segment[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const { skeleton: publicSkeleton, values } = skeletonize(lines[i]!);
+    // A run is templatable only if the skeleton actually has a variable slot.
+    if (values.length > 0) {
+      let j = i + 1;
+      const rows: string[][] = [values];
+      while (j < lines.length) {
+        const next = skeletonize(lines[j]!);
+        if (next.skeleton !== publicSkeleton || next.values.length === 0) break;
+        rows.push(next.values);
+        j++;
+      }
+      if (rows.length >= MIN_RUN) {
+        // Store internal skeleton (with markers) in mapping
+        const { skeleton: internalSkeleton } = internalizeSkeletonize(lines[i]!);
+        segments.push({ kind: 'group', skeleton: internalSkeleton, rows });
+        i = j;
+        continue;
+      }
+    }
+    // Not a run: accumulate into the current raw segment.
+    const last = segments[segments.length - 1];
+    if (last && last.kind === 'raw') last.lines.push(lines[i]!);
+    else segments.push({ kind: 'raw', lines: [lines[i]!] });
+    i++;
+  }
+
+  const rendered = segments
+    .map((seg) => {
+      if (seg.kind === 'raw') return seg.lines.join('\n');
+      const header = `Template: ${skeletonToTemplate(seg.skeleton)}`;
+      const rows = seg.rows.map((r) => r.join(',')).join('\n');
+      return `${header}\nRows:\n${rows}`;
+    })
+    .join('\n');
+
+  return { text: rendered, mapping: { segments } };
+}
+
+export function reconstruct(mapping: TemplateMapping): string {
+  const out: string[] = [];
+  for (const seg of mapping.segments) {
+    if (seg.kind === 'raw') {
+      out.push(seg.lines.join('\n'));
+      continue;
+    }
+    const parts = seg.skeleton.split(INTERNAL_MARKER);
+    for (const row of seg.rows) {
+      let line = parts[0]!;
+      for (let k = 0; k < row.length; k++) line += row[k]! + parts[k + 1]!;
+      out.push(line);
+    }
+  }
+  return out.join('\n');
+}

--- a/eval/template-compression/templatize.ts
+++ b/eval/template-compression/templatize.ts
@@ -5,13 +5,14 @@
 // asserts — skeleton + row values reconstruct each original line exactly, and
 // blocks stay in original position (contiguous runs only, so nothing reorders).
 
-// For public API, SENTINEL is empty (skeletonize returns skeletons without visible markers).
-// Internally, we use an invisible marker for split/join operations.
-export const SENTINEL = '';
+// SENTINEL is an in-band record-separator marker. skeletonize replaces every
+// digit run with it, so the skeleton does double duty: it groups lines by
+// identical variable LAYOUT (same marker positions AND count), and it splits
+// cleanly for reconstruction. Grouping on a marker-less skeleton would merge
+// lines whose digits sit in different places (e.g. `a1b1c` and `ab4c4` both
+// reduce to `abc`) and corrupt reconstruction — the marker keeps layouts distinct.
+export const SENTINEL = '\x1E';
 export const MIN_RUN = 3;
-
-// Internal marker using record separator character (invisible in normal use)
-const INTERNAL_MARKER = '\x1E';
 
 export interface SkeletonResult {
   skeleton: string;
@@ -27,16 +28,6 @@ export function skeletonize(line: string): SkeletonResult {
   return { skeleton, values };
 }
 
-// Convert skeleton from public format (no markers) to internal format (with markers)
-function internalizeSkeletonize(line: string): { skeleton: string; values: string[] } {
-  const values: string[] = [];
-  const skeleton = line.replace(/[0-9]+/g, (m) => {
-    values.push(m);
-    return INTERNAL_MARKER;
-  });
-  return { skeleton, values };
-}
-
 export type Segment =
   | { kind: 'raw'; lines: string[] }
   | { kind: 'group'; skeleton: string; rows: string[][] };
@@ -46,7 +37,7 @@ export interface TemplateMapping {
 }
 
 function skeletonToTemplate(skeleton: string): string {
-  return skeleton.split(INTERNAL_MARKER).join('{}');
+  return skeleton.split(SENTINEL).join('{}');
 }
 
 export function templatize(text: string): { text: string; mapping: TemplateMapping } {
@@ -54,21 +45,21 @@ export function templatize(text: string): { text: string; mapping: TemplateMappi
   const segments: Segment[] = [];
   let i = 0;
   while (i < lines.length) {
-    const { skeleton: publicSkeleton, values } = skeletonize(lines[i]!);
+    const { skeleton, values } = skeletonize(lines[i]!);
     // A run is templatable only if the skeleton actually has a variable slot.
     if (values.length > 0) {
       let j = i + 1;
       const rows: string[][] = [values];
       while (j < lines.length) {
         const next = skeletonize(lines[j]!);
-        if (next.skeleton !== publicSkeleton || next.values.length === 0) break;
+        // Marker-bearing skeleton: identical string ⇒ identical variable layout,
+        // so every grouped row has the same slot count and positions (lossless).
+        if (next.skeleton !== skeleton) break;
         rows.push(next.values);
         j++;
       }
       if (rows.length >= MIN_RUN) {
-        // Store internal skeleton (with markers) in mapping
-        const { skeleton: internalSkeleton } = internalizeSkeletonize(lines[i]!);
-        segments.push({ kind: 'group', skeleton: internalSkeleton, rows });
+        segments.push({ kind: 'group', skeleton, rows });
         i = j;
         continue;
       }
@@ -99,7 +90,7 @@ export function reconstruct(mapping: TemplateMapping): string {
       out.push(seg.lines.join('\n'));
       continue;
     }
-    const parts = seg.skeleton.split(INTERNAL_MARKER);
+    const parts = seg.skeleton.split(SENTINEL);
     for (const row of seg.rows) {
       let line = parts[0]!;
       for (let k = 0; k < row.length; k++) line += row[k]! + parts[k + 1]!;

--- a/tests/template-compression-corpus.test.ts
+++ b/tests/template-compression-corpus.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { CORPUS } from '../eval/template-compression/fixtures/corpus.js';
+import { templatize, reconstruct } from '../eval/template-compression/templatize.js';
+
+describe('template-compression corpus', () => {
+  it('covers all three tiers', () => {
+    const tiers = new Set(CORPUS.map((s) => s.tier));
+    expect(tiers).toEqual(new Set(['best', 'typical', 'worst']));
+  });
+
+  it('every sample is losslessly templatizable', () => {
+    for (const s of CORPUS) {
+      expect(reconstruct(templatize(s.text).mapping), s.id).toBe(s.text);
+    }
+  });
+
+  it("every query's exact answer literally appears in its sample text", () => {
+    for (const s of CORPUS) {
+      for (const query of s.queries) {
+        expect(s.text.includes(query.exact), `${s.id}/${query.id}`).toBe(true);
+      }
+    }
+  });
+
+  it('worst-tier samples gain little from templating (<5% line-collapse)', () => {
+    for (const s of CORPUS.filter((x) => x.tier === 'worst')) {
+      const before = s.text.split('\n').length;
+      const after = templatize(s.text).text.split('\n').length;
+      expect(after / before, s.id).toBeGreaterThan(0.95);
+    }
+  });
+});

--- a/tests/template-compression-read.test.ts
+++ b/tests/template-compression-read.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { readArm } from '../eval/template-compression/read-ab.js';
+import type { AskImages } from '../eval/template-compression/read-ab.js';
+import type { Query } from '../eval/template-compression/fixtures/corpus.js';
+
+describe('read-ab scoring', () => {
+  it('classifies a correct exact answer and a confabulated one', async () => {
+    // The `claude -p` transport is the only impure seam. readArm takes it as an
+    // injected last param (default = the real askImages), so the test passes a
+    // stub directly instead of relying on ESM module-binding spies — vi.spyOn on
+    // a named export does not reliably intercept a call the module makes to its
+    // own local binding, which would let this test silently spawn a real process.
+    const stubAsk: AskImages = async (_pngs, q) => (q.id === 'ok' ? '60' : '999');
+    const queries: Query[] = [
+      { id: 'ok', q: 'x', exact: '60' },
+      { id: 'bad', q: 'y', exact: '60' },
+    ];
+    const out = await readArm('templated', '10\n20\n30', queries, 'claude-fable-5', 1, stubAsk);
+    expect(out.find((o) => o.queryId === 'ok')!.outcome).toBe('correct');
+    expect(out.find((o) => o.queryId === 'bad')!.outcome).toBe('silent_wrong');
+  });
+});

--- a/tests/template-compression-tokens.test.ts
+++ b/tests/template-compression-tokens.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { measureSample } from '../eval/template-compression/measure-tokens.js';
+import { CORPUS } from '../eval/template-compression/fixtures/corpus.js';
+
+describe('measure-tokens', () => {
+  it('reports a positive reduction on a best-tier sample', async () => {
+    const best = CORPUS.find((s) => s.id === 'best-worker-log')!;
+    const r = await measureSample(best.text, 'claude-fable-5');
+    expect(r.templated.imageTokens).toBeLessThan(r.raw.imageTokens);
+    expect(r.reductionPct).toBeGreaterThan(0);
+  });
+});

--- a/tests/template-compression-verdict.test.ts
+++ b/tests/template-compression-verdict.test.ts
@@ -2,16 +2,25 @@ import { describe, expect, it } from 'vitest';
 import { verdict } from '../eval/template-compression/run.js';
 
 describe('go/no-go verdict', () => {
-  it('is GO only when all four criteria hold', () => {
-    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(true);
+  it('is GO only when all criteria hold', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0, totalReads: 10 }).go).toBe(true);
   });
   it('is NO-GO on any confabulation', () => {
-    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 1, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(false);
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 1, worstReductionPct: 1, worstRecallDelta: 0, totalReads: 10 }).go).toBe(false);
   });
   it('is NO-GO when reduction is under 20%', () => {
-    expect(verdict({ repetitiveReductionPct: 12, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(false);
+    expect(verdict({ repetitiveReductionPct: 12, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0, totalReads: 10 }).go).toBe(false);
   });
   it('is NO-GO when templated recall regresses below raw', () => {
-    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.7, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(false);
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.7, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0, totalReads: 10 }).go).toBe(false);
+  });
+  it('is NO-GO when no reads occurred (reading safety unverified)', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0, totalReads: 0 }).go).toBe(false);
+  });
+  it('is NO-GO when raw-arm recall is too low to certify', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.3, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0, totalReads: 10 }).go).toBe(false);
+  });
+  it('is NO-GO when worst-tier tokens bloat', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: -5, worstRecallDelta: 0, totalReads: 10 }).go).toBe(false);
   });
 });

--- a/tests/template-compression-verdict.test.ts
+++ b/tests/template-compression-verdict.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { verdict } from '../eval/template-compression/run.js';
+
+describe('go/no-go verdict', () => {
+  it('is GO only when all four criteria hold', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(true);
+  });
+  it('is NO-GO on any confabulation', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 1, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(false);
+  });
+  it('is NO-GO when reduction is under 20%', () => {
+    expect(verdict({ repetitiveReductionPct: 12, templatedRecall: 0.9, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(false);
+  });
+  it('is NO-GO when templated recall regresses below raw', () => {
+    expect(verdict({ repetitiveReductionPct: 25, templatedRecall: 0.7, rawRecall: 0.9, confabulations: 0, worstReductionPct: 1, worstRecallDelta: 0 }).go).toBe(false);
+  });
+});

--- a/tests/template-compression.test.ts
+++ b/tests/template-compression.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import { templatize, reconstruct, skeletonize } from '../eval/template-compression/templatize.js';
+
+describe('templatize', () => {
+  it('skeletonizes digit runs and captures values in order', () => {
+    expect(skeletonize('worker-7 request 4832 failed after 30 sec')).toEqual({
+      skeleton: 'worker- request  failed after  sec',
+      values: ['7', '4832', '30'],
+    });
+  });
+
+  it('collapses a contiguous run of same-shape lines into a Template/Rows block', () => {
+    const raw = [
+      'worker-7 request 4832 failed after 30 sec',
+      'worker-7 request 4833 failed after 60 sec',
+      'worker-8 request 4834 failed after 60 sec',
+    ].join('\n');
+    const { text } = templatize(raw);
+    expect(text).toBe(
+      'Template: worker-{} request {} failed after {} sec\nRows:\n7,4832,30\n7,4833,60\n8,4834,60',
+    );
+  });
+
+  it('is lossless: reconstruct(templatize(x)) === x', () => {
+    const raw = [
+      'worker-7 request 4832 failed after 30 sec',
+      'worker-7 request 4833 failed after 60 sec',
+      'worker-8 request 4834 failed after 60 sec',
+    ].join('\n');
+    expect(reconstruct(templatize(raw).mapping)).toBe(raw);
+  });
+
+  it('leaves non-repetitive text untouched (run shorter than MIN_RUN)', () => {
+    const raw = 'hello world\njust one 42 number\nthe end';
+    const { text, mapping } = templatize(raw);
+    expect(text).toBe(raw);
+    expect(mapping.segments).toEqual([{ kind: 'raw', lines: raw.split('\n') }]);
+    expect(reconstruct(mapping)).toBe(raw);
+  });
+
+  it('only groups lines that actually vary (skeleton must contain a variable)', () => {
+    const raw = 'same line\nsame line\nsame line';
+    // identical lines have no digit variable -> not a template win, passthrough
+    expect(templatize(raw).text).toBe(raw);
+  });
+
+  it('round-trips mixed raw + grouped + raw with values at line edges', () => {
+    const raw = [
+      'header',
+      '10 apples',
+      '20 apples',
+      '30 apples',
+      'footer 9',
+    ].join('\n');
+    expect(reconstruct(templatize(raw).mapping)).toBe(raw);
+    expect(templatize(raw).text).toContain('Template: {} apples');
+  });
+});

--- a/tests/template-compression.test.ts
+++ b/tests/template-compression.test.ts
@@ -4,7 +4,7 @@ import { templatize, reconstruct, skeletonize } from '../eval/template-compressi
 describe('templatize', () => {
   it('skeletonizes digit runs and captures values in order', () => {
     expect(skeletonize('worker-7 request 4832 failed after 30 sec')).toEqual({
-      skeleton: 'worker- request  failed after  sec',
+      skeleton: 'worker-\x1E request \x1E failed after \x1E sec',
       values: ['7', '4832', '30'],
     });
   });
@@ -54,5 +54,13 @@ describe('templatize', () => {
     ].join('\n');
     expect(reconstruct(templatize(raw).mapping)).toBe(raw);
     expect(templatize(raw).text).toContain('Template: {} apples');
+  });
+
+  it('stays lossless when digit positions differ across same-letter lines', () => {
+    // 'a1b1c'/'a2b2c'/'a3b3c' share the layout 'a{}b{}c'; 'ab4c4' has the same
+    // letters but a DIFFERENT digit layout ('ab{}c{}'). Grouping on a marker-less
+    // skeleton would merge it and corrupt the round-trip — the marker prevents that.
+    const raw = ['a1b1c', 'a2b2c', 'a3b3c', 'ab4c4'].join('\n');
+    expect(reconstruct(templatize(raw).mapping)).toBe(raw);
   });
 });


### PR DESCRIPTION
## What

A **product-isolated, $0-capable measurement harness** under `eval/template-compression/` that answers one go/no-go: does templatizing repetitive tool-output lines before render cut image tokens without regressing exact-value reading accuracy? Nothing under `src/core/` changes — the harness only imports from it.

Built via brainstorming → spec → plan → subagent-driven TDD (spec + plan under `docs/superpowers/`).

## Result so far (the $0 token half)

`tsx eval/template-compression/run.ts --dry-run` → **repetitive reduction 60.8% · worst 0.0%** — well above the 20% bar, and zero harm on non-repetitive text.

**Key finding:** image billing is **page/tile-quantized**, so templating cuts tokens only once the shorter text saves whole rendered pages. A 40-line log fits one page in both arms (0% measured); realistic verbose dumps (~800 lines) spill the raw arm to 2-3 pages while the templated arm stays one → the ~65-79% character cut shows up as real token savings. The corpus is sized accordingly.

## Components

- `templatize.ts` — pure, **lossless** digit-skeleton templatizer (`reconstruct(templatize(x)) === x`), regression-guarded against the layout-collision bug.
- `fixtures/corpus.ts` — three tiers (best / typical / worst), numeric exact-value queries.
- `measure-tokens.ts` — dual-arm token math via the real render + billing.
- `read-ab.ts` — paired A/B exact-recall reads via the `claude -p` transport (injectable, stubbed offline in tests), reusing `density-frontier`'s `scoreAnswer` (fail-closed: wrong-but-confident = `silent_wrong`).
- `run.ts` — orchestrator + hardened go/no-go `verdict` (GO only if ≥20% reduction AND templated recall ≥ raw AND zero confabulations AND worst-tier unharmed AND reads actually occurred with a credible raw-arm recall).

## Remaining for the full go/no-go

The **live reading A/B** (`tsx eval/template-compression/run.ts`, needs the `claude` CLI on PATH; still $0 via subscription) — this measures the reading-safety half. The token half already clears the bar.

Validation: full suite **1116/1116**, lint · typecheck · build clean, corpus secret-clean.