### PR TITLE
fix(transform): keep automode state out of static images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic ver
 
 ### Fixed
 
+- **fix(transform):** keep Claude Code automode rules, permissions, severity
+  and category in the per-turn dynamic tail so they cannot invalidate the
+  cacheable rendered prefix. (thanks @parziva-1)
 - **fix(render):** glyph surgery so the Spleen 5×8 `K` no longer reads as `H`.
   The stock bitmap `K` was `H` with a single crossbar pixel removed (Hamming 1) —
   the worst confusable pair in the atlas, so an imaged `K` could be read back as

--- a/src/core/transform.ts
+++ b/src/core/transform.ts
@@ -760,6 +760,14 @@ const DYNAMIC_BLOCK_TAGS = [
   'git_status',
   'directoryStructure',
   'system-reminder',
+  // Claude Code automode state changes as grants and classifications evolve
+  // during a session. Keeping these fields in the static slab re-keys the
+  // rendered prefix on every turn and can break subscription identity/quota
+  // recognition, so they belong in the uncached dynamic tail.
+  'cc_automode_session_rules',
+  'cc_automode_permissions',
+  'severity',
+  'category',
 ] as const;
 
 // Known-static slab tags — suppresses first-sighting `unknownStaticTags` noise

--- a/tests/dynamic-automode-tags.test.ts
+++ b/tests/dynamic-automode-tags.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { transformRequest } from '../src/core/transform.js';
+
+const enc = (permission: string, severity: string): Uint8Array =>
+  new TextEncoder().encode(JSON.stringify({
+    model: 'claude-fable-5',
+    system: [{
+      type: 'text',
+      text: [
+        'You are a helpful assistant.',
+        'x'.repeat(40_000),
+        '<cc_automode_session_rules>ask before acting</cc_automode_session_rules>',
+        `<cc_automode_permissions>${permission}</cc_automode_permissions>`,
+        `<severity>${severity}</severity>`,
+        '<category>filesystem</category>',
+      ].join('\n'),
+    }],
+    messages: [{ role: 'user', content: 'go' }],
+  }));
+
+describe('Claude Code automode state', () => {
+  it('routes all automode fields out of the static slab', async () => {
+    const first = await transformRequest(enc('read', 'info'));
+    const second = await transformRequest(enc('read,write,admin', 'warning'));
+
+    expect(first.info.imageCount).toBeGreaterThan(0);
+    expect(first.info.systemSha8).toBeDefined();
+    expect(second.info.systemSha8).toBe(first.info.systemSha8);
+
+    const unknown = first.info.unknownStaticTags ?? [];
+    expect(unknown).not.toContain('cc_automode_session_rules');
+    expect(unknown).not.toContain('cc_automode_permissions');
+    expect(unknown).not.toContain('severity');
+    expect(unknown).not.toContain('category');
+
+    expect(first.info.dynamicChars ?? 0).toBeGreaterThan(0);
+    expect(second.info.dynamicChars).not.toBe(first.info.dynamicChars);
+  });
+});


### PR DESCRIPTION
## Summary

- classify automode session rules and permissions as per-turn dynamic state
- keep severity and category fields out of the cacheable static image slab
- preserve a stable system fingerprint while allowing the dynamic tail to change

## Validation

- focused dynamic-tag regression added before the implementation
- lint passed
- typecheck passed
- build passed
- full suite: 1,117 tests passed