### PR TITLE
chore(release): 1.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic ver
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-08-17
+
 ### Added
 
 - **feat(accounting):** provider-neutral physical-usage normalization with
@@ -28,6 +30,16 @@ Format: [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) · semantic ver
   keys, race-safe byte accounting, smaller Worker defaults, runtime budget
   control and cache-pressure counters in `/proxy-stats`. (thanks
   @viacheslav-khvorostianyi)
+
+### Security
+
+- **security(secret-guard):** remove the polynomial-backtracking paths from
+  PEM private-key and secret-assignment detection. The guard now scans bounded
+  PEM marker headers and assignment names linearly; adversarial-input tests
+  keep the text-to-image safety boundary responsive under repeated prefixes.
+- **security(deps):** resolve all audited vulnerable transitives, including
+  `sharp`, `undici`, `postcss`, `nanoid`, and `brace-expansion`. pnpm overrides
+  now live in `pnpm-workspace.yaml`, the configuration location pnpm 10 reads.
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "omniglyph",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "description": "Context-as-image compression proxy for LLMs: renders bulky context (system prompt, tool docs, history) as dense PNG pages with exact per-provider billing math (Anthropic/OpenAI/Gemini). Node and Cloudflare Workers. Part of the OmniRoute family.",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Release 1.4.0

Consolidates all changes shipped since 1.3.1:
- provider-neutral usage accounting and caller-selected compression profiles
- render-cache hardening, history/reflow fixes, rendered-context provenance, and glyph legibility repair
- the full security remediation: linear secret scans plus patched dependency graph

## Release validation
- pnpm install --frozen-lockfile
- pnpm audit --json: 0 vulnerabilities
- pnpm run lint
- pnpm run typecheck
- pnpm run build: CLI reports 1.4.0
- pnpm test: 1,157 passed